### PR TITLE
feat: split up liquidation penalty into two beneficiaries (protocol & liquidator)

### DIFF
--- a/clarity/contracts/auction-engine-trait.clar
+++ b/clarity/contracts/auction-engine-trait.clar
@@ -5,6 +5,6 @@
   (
     ;; make this part of the trait when bug is fixed: (get-minimum-collateral-amount (<oracle-trait> uint) (response uint bool))
     (fetch-minimum-collateral-amount (<oracle-trait> uint) (response uint uint))
-    (start-auction (uint uint uint) (response bool uint))
+    (start-auction (uint uint uint uint uint) (response bool uint))
   )
 )

--- a/clarity/contracts/auction-engine.clar
+++ b/clarity/contracts/auction-engine.clar
@@ -1,4 +1,4 @@
-;; (impl-trait .auction-engine-trait.auction-engine-trait)
+(impl-trait .auction-engine-trait.auction-engine-trait)
 (use-trait vault-trait .vault-trait.vault-trait)
 (use-trait mock-ft-trait .mock-ft-trait.mock-ft-trait)
 (use-trait vault-manager-trait .vault-manager-trait.vault-manager-trait)

--- a/clarity/contracts/auction-engine.clar
+++ b/clarity/contracts/auction-engine.clar
@@ -165,9 +165,12 @@
   )
 )
 
-(define-read-only (discounted-auction-price (price-in-cents uint) (discount-percentage uint))
+(define-read-only (discounted-auction-price (price-in-cents uint) (auction-id uint))
   ;; price * 3% = price * 3 / 100
-  (let ((discount (* price-in-cents discount-percentage)))
+  (let (
+    (auction (get-auction-by-id auction-id))
+    (discount (* price-in-cents (get discount auction)))
+  )
     (ok (/ (- (* u100 price-in-cents) discount) u100))
   )
 )
@@ -191,7 +194,7 @@
     (auction (get-auction-by-id auction-id))
     (collateral-left (- (get collateral-amount auction) (get total-collateral-sold auction)))
     (debt-left-to-raise (- (get debt-to-raise auction) (get total-debt-raised auction)))
-    (discounted-price (unwrap-panic (discounted-auction-price collateral-price-in-cents (get discount auction))))
+    (discounted-price (unwrap-panic (discounted-auction-price collateral-price-in-cents auction-id)))
   )
     (if (< debt-left-to-raise (get lot-size auction))
       (let ((collateral-amount (/ (* u100 debt-left-to-raise) discounted-price)))

--- a/clarity/contracts/auction-engine.clar
+++ b/clarity/contracts/auction-engine.clar
@@ -379,7 +379,7 @@
 
 (define-private (return-xusd (owner principal) (xusd uint))
   (if (> xusd u0)
-    (ok (unwrap-panic (as-contract (contract-call? .xusd-token transfer xusd (as-contract tx-sender) owner))))
+    (as-contract (contract-call? .xusd-token transfer xusd (as-contract tx-sender) owner))
     (err u0) ;; don't really care if this fails.
   )
 )

--- a/clarity/contracts/collateral-types.clar
+++ b/clarity/contracts/collateral-types.clar
@@ -194,7 +194,7 @@
       liquidation-ratio: u150,
       collateral-to-debt-ratio: u200,
       maximum-debt: u100000000000000,
-      liquidation-penalty: u10,
+      liquidation-penalty: u1000, ;; 10% in basis points
       stability-fee: u1648, ;; 0.001363077% daily percentage == 1% APY
       stability-fee-apy: u50 ;; 50 basis points
     }
@@ -210,7 +210,7 @@
       liquidation-ratio: u115,
       collateral-to-debt-ratio: u200,
       maximum-debt: u10000000000000,
-      liquidation-penalty: u10,
+      liquidation-penalty: u1000,
       stability-fee: u3296, ;; 0.002726155% daily percentage == 1% APY
       stability-fee-apy: u100 ;; 100 basis points
     }
@@ -226,7 +226,7 @@
       liquidation-ratio: u200,
       collateral-to-debt-ratio: u300,
       maximum-debt: u10000000000000,
-      liquidation-penalty: u13,
+      liquidation-penalty: u1300,
       stability-fee: u3296, ;; 0.002726155% daily percentage == 1% APY
       stability-fee-apy: u100
     }

--- a/clarity/contracts/freddie.clar
+++ b/clarity/contracts/freddie.clar
@@ -436,7 +436,13 @@
     (asserts! (is-eq (unwrap-panic (contract-call? .dao get-emergency-shutdown-activated)) false) (err ERR-EMERGENCY-SHUTDOWN-ACTIVATED))
     (asserts! (is-eq contract-caller .liquidator) (err ERR-NOT-AUTHORIZED))
 
-    (let ((collateral (get collateral vault)))
+    (let (
+      (collateral (get collateral vault))
+      (liquidation-penalty (unwrap-panic (contract-call? .collateral-types get-liquidation-penalty (get collateral-type vault))))
+      (penalty (/ (* liquidation-penalty (get debt vault)) u10000))
+      (extra-debt (/ (* u60 penalty) u100)) ;; 60% of the penalty is extra debt.
+      (discount (/ (* u40 liquidation-penalty) u100)) ;; 40% of liquidation penalty is discount % for liquidator
+    )
       (if
         (and
           (is-eq "STX" (get collateral-token vault))
@@ -454,9 +460,7 @@
             }))
           )
           (try! (contract-call? .sip10-reserve mint-xstx collateral))
-          (let ((debt (/ (* (unwrap-panic (contract-call? .collateral-types get-liquidation-penalty (get collateral-type vault))) (get debt vault)) u100)))
-            (ok (tuple (ustx-amount collateral) (debt (+ debt (get debt vault)))))
-          )
+          (ok (tuple (ustx-amount collateral) (extra-debt extra-debt) (vault-debt (get debt vault)) (discount discount)))
         )
         (begin
           (try! (contract-call? .vault-data update-vault vault-id (merge vault {
@@ -467,9 +471,7 @@
               leftover-collateral: u0
             }))
           )
-          (let ((debt (/ (* (unwrap-panic (contract-call? .collateral-types get-liquidation-penalty (get collateral-type vault))) (get debt vault)) u100)))
-            (ok (tuple (ustx-amount collateral) (debt (+ debt (get debt vault)))))
-          )
+          (ok (tuple (ustx-amount collateral) (extra-debt extra-debt) (vault-debt (get debt vault)) (discount discount)))
         )
       )
     )

--- a/clarity/contracts/freddie.clar
+++ b/clarity/contracts/freddie.clar
@@ -441,7 +441,7 @@
       (liquidation-penalty (unwrap-panic (contract-call? .collateral-types get-liquidation-penalty (get collateral-type vault))))
       (penalty (/ (* liquidation-penalty (get debt vault)) u10000))
       (extra-debt (/ (* u60 penalty) u100)) ;; 60% of the penalty is extra debt.
-      (discount (/ (* u40 liquidation-penalty) u100)) ;; 40% of liquidation penalty is discount % for liquidator
+      (discount (/ (* u40 liquidation-penalty) u10000)) ;; 40% of liquidation penalty is discount % for liquidator
     )
       (if
         (and

--- a/clarity/contracts/liquidator.clar
+++ b/clarity/contracts/liquidator.clar
@@ -24,7 +24,13 @@
     (let 
       ((amounts (unwrap-panic (as-contract (contract-call? vault-manager liquidate vault-id)))))
         (unwrap! 
-          (contract-call? auction-engine start-auction vault-id (get ustx-amount amounts) (get debt amounts)) 
+          (contract-call? auction-engine start-auction
+            vault-id
+            (get ustx-amount amounts)
+            (get extra-debt amounts)
+            (get vault-debt amounts)
+            (get discount amounts)
+          ) 
           (err ERR-LIQUIDATION-FAILED))
         (ok STATUS-OK)
     )

--- a/clarity/contracts/stacker.clar
+++ b/clarity/contracts/stacker.clar
@@ -158,7 +158,7 @@
   (let (
     (stx-in-vault (var-get stacking-stx-in-vault))
     (percentage (/ (* u100000 (get collateral-amount data)) stx-in-vault)) ;; in basis points
-    (basis-points (/ (* u100000 stx-in-vault) (var-get stacking-stx-stacked)))
+    (basis-points (/ (* u100000 stx-in-vault) (var-get stacking-stx-stacked))) ;; this gives the percentage of collateral bought in auctions vs stx stacked
     (earned-amount-vault (/ (* (var-get stacking-stx-received) basis-points) u100000))
     (earned-amount-bidder (/ (* percentage earned-amount-vault) u100000))
   )

--- a/clarity/contracts/stacker.clar
+++ b/clarity/contracts/stacker.clar
@@ -121,7 +121,13 @@
     (vault (contract-call? .vault-data get-vault-by-id vault-id))
   )
     (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
-    (asserts! (is-eq "STX" (get collateral-token vault)) (err ERR-NOT-AUTHORIZED))
+    (asserts!
+      (or
+        (is-eq "xSTX" (get collateral-token vault))
+        (is-eq "STX" (get collateral-token vault))
+      )
+      (err ERR-NOT-AUTHORIZED)
+    )
     (asserts! (>= burn-block-height (var-get stacking-unlock-burn-height)) (err ERR-BURN-HEIGHT-NOT-REACHED))
 
     (if (and (get is-liquidated vault) (get auction-ended vault))
@@ -151,10 +157,10 @@
 (define-private (payout-lot-bidder (data (tuple (collateral-amount uint) (recipient principal))))
   (let (
     (stx-in-vault (var-get stacking-stx-in-vault))
-    (percentage (/ (* u10000 (get collateral-amount data)) stx-in-vault)) ;; in basis points
-    (basis-points (/ (* u10000 stx-in-vault) (var-get stacking-stx-stacked)))
-    (earned-amount-vault (/ (* (var-get stacking-stx-received) basis-points) u10000))
-    (earned-amount-bidder (/ (* percentage earned-amount-vault) u10000))
+    (percentage (/ (* u100000 (get collateral-amount data)) stx-in-vault)) ;; in basis points
+    (basis-points (/ (* u100000 stx-in-vault) (var-get stacking-stx-stacked)))
+    (earned-amount-vault (/ (* (var-get stacking-stx-received) basis-points) u100000))
+    (earned-amount-bidder (/ (* percentage earned-amount-vault) u100000))
   )
     (try! (as-contract (stx-transfer? earned-amount-bidder (as-contract tx-sender) (get recipient data))))
     (ok true)

--- a/clarity/contracts/vault-manager-trait.clar
+++ b/clarity/contracts/vault-manager-trait.clar
@@ -8,7 +8,7 @@
     (get-collateral-type-for-vault (uint) (response (string-ascii 12) bool))
     (calculate-current-collateral-to-debt-ratio (uint) (response uint uint))
 
-    (liquidate (uint) (response (tuple (ustx-amount uint) (debt uint)) uint))
+    (liquidate (uint) (response (tuple (ustx-amount uint) (extra-debt uint) (vault-debt uint) (discount uint)) uint))
     (finalize-liquidation (uint uint) (response bool uint))
 
     (redeem-auction-collateral (<mock-ft-trait> <vault-trait> uint principal) (response bool uint))

--- a/clarity/tests/stacker_test.ts
+++ b/clarity/tests/stacker_test.ts
@@ -289,7 +289,7 @@ Clarinet.test({
         types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.oracle'),
         types.uint(1),
         types.uint(1),
-        types.uint(296551724 * 1.5) // 1.5 (price of STX) * minimum collateral
+        types.uint(432965517) // 1.46 (price of STX) * minimum collateral: 296551724 * 1.46
       ], deployer.address)
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
@@ -310,7 +310,7 @@ Clarinet.test({
       wallet_1.address
     );
     let vault = call.result.expectTuple();
-    vault['leftover-collateral'].expectUint(13793104);
+    vault['leftover-collateral'].expectUint(43055556);
     vault['is-liquidated'].expectBool(true);
     vault['auction-ended'].expectBool(true);
 
@@ -329,10 +329,10 @@ Clarinet.test({
     let [stxTransferEvent1, stxTransferEvent2] = block.receipts[1].events;
     stxTransferEvent1.stx_transfer_event.sender.expectPrincipal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stacker");
     stxTransferEvent1.stx_transfer_event.recipient.expectPrincipal(deployer.address);
-    stxTransferEvent1.stx_transfer_event.amount.expectInt(310342347);
+    stxTransferEvent1.stx_transfer_event.amount.expectInt(312494498);
 
     stxTransferEvent2.stx_transfer_event.sender.expectPrincipal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stacker");
     stxTransferEvent2.stx_transfer_event.recipient.expectPrincipal(deployer.address);
-    stxTransferEvent2.stx_transfer_event.amount.expectInt(133403274);
+    stxTransferEvent2.stx_transfer_event.amount.expectInt(118124195);
   }
 });

--- a/scripts/scan-vaults.js
+++ b/scripts/scan-vaults.js
@@ -8,7 +8,7 @@ const BN = require('bn.js');
 async function getLastVaultId() {
   const lastVaultTx = await tx.callReadOnlyFunction({
     contractAddress: CONTRACT_ADDRESS,
-    contractName: "freddie",
+    contractName: "vault-data",
     functionName: "get-last-vault-id",
     functionArgs: [],
     senderAddress: CONTRACT_ADDRESS,
@@ -47,7 +47,7 @@ async function getCollateralizationRatio(vaultId) {
 async function getLiquidationRatio(collateralType) {
   const vaultTx = await tx.callReadOnlyFunction({
     contractAddress: CONTRACT_ADDRESS,
-    contractName: "dao",
+    contractName: "collateral-types",
     functionName: "get-liquidation-ratio",
     functionArgs: [tx.stringAsciiCV(collateralType)],
     senderAddress: CONTRACT_ADDRESS,
@@ -63,7 +63,11 @@ async function liquidateVault(vaultId) {
     contractAddress: CONTRACT_ADDRESS,
     contractName: "liquidator",
     functionName: "notify-risky-vault",
-    functionArgs: [tx.uintCV(vaultId)],
+    functionArgs: [
+      tx.contractPrincipalCV(CONTRACT_ADDRESS, 'freddie'),
+      tx.contractPrincipalCV(CONTRACT_ADDRESS, 'auction-engine'),
+      tx.uintCV(vaultId)
+    ],
     senderKey: process.env.STACKS_PRIVATE_KEY,
     postConditionMode: 1,
     nonce: new BN(nonce),

--- a/scripts/update-price.js
+++ b/scripts/update-price.js
@@ -24,7 +24,7 @@ const network = utils.resolveNetwork();
 
 rp(requestOptions).then(async (response) => {
   let price = response['data']['4847']['quote']['USD']['price'];
-  // price = 1.49;
+  price = 1.72;
   let nonce = await utils.getNonce(CONTRACT_ADDRESS);
 
   const txOptions = {

--- a/web/components/app.tsx
+++ b/web/components/app.tsx
@@ -115,7 +115,7 @@ export const App: React.FC = () => {
         url: json.value['url'].value,
         totalDebt: json.value['total-debt'].value,
         collateralToDebtRatio: json.value['collateral-to-debt-ratio'].value,
-        liquidationPenalty: json.value['liquidation-penalty'].value,
+        liquidationPenalty: json.value['liquidation-penalty'].value / 100,
         liquidationRatio: json.value['liquidation-ratio'].value,
         maximumDebt: json.value['maximum-debt'].value,
         stabilityFee: json.value['stability-fee'].value,

--- a/web/components/app.tsx
+++ b/web/components/app.tsx
@@ -121,10 +121,9 @@ export const App: React.FC = () => {
         stabilityFee: json.value['stability-fee'].value,
         stabilityFeeApy: json.value['stability-fee-apy'].value
       };
-
       setState(prevState => ({
         ...prevState,
-        collateralTypes: collTypes
+        collateralTypes: {...collTypes}
       }));
     });
   };

--- a/web/components/auction-group.tsx
+++ b/web/components/auction-group.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Auction } from './auction';
 import { Modal } from '@blockstack/ui';
-import { uintCV } from '@stacks/transactions';
+import { contractPrincipalCV, uintCV } from '@stacks/transactions';
 import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { connectWebSocketClient } from '@stacks/blockchain-api-client';
@@ -79,7 +79,13 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions }) => {
       contractAddress,
       contractName: 'auction-engine',
       functionName: 'bid',
-      functionArgs: [uintCV(bidAuctionId), uintCV(bidLotId), uintCV(bidAmount * 1000000)],
+      functionArgs: [
+        contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', 'freddie'),
+        contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', 'oracle'),
+        uintCV(bidAuctionId),
+        uintCV(bidLotId),
+        uintCV(bidAmount * 1000000)
+      ],
       postConditionMode: 0x01,
       finished: data => {
         console.log('finished bidding!', data);

--- a/web/components/auction.tsx
+++ b/web/components/auction.tsx
@@ -29,10 +29,8 @@ export const Auction: React.FC<AuctionProps> = ({ id, lotId, collateralToken, en
         senderAddress: stxAddress || '',
         network: network,
       });
-      console.log(discountedPriceCall);
       const json = cvToJSON(discountedPriceCall);
-      console.log(json);
-      setDiscountedPrice(price - (price * 0.04)); // TODO: change for discounted-auction-price on auction-engine SC. 4% = 40% of 10% liquidation penalty
+      setDiscountedPrice(json.value.value);
     };
 
     fetchPrice();
@@ -53,7 +51,7 @@ export const Auction: React.FC<AuctionProps> = ({ id, lotId, collateralToken, en
 
       const collJson = cvToJSON(minimumCollateralAmount);
       setMinimumCollateralAmount(collJson.value.value);
-      const debtMax = 100000000;
+      const debtMax = 1000000000;
       setDebtToRaise(Math.min(debtMax, collJson.value.value * discountedPrice / 100));
 
       const currentBid = await callReadOnlyFunction({
@@ -75,12 +73,12 @@ export const Auction: React.FC<AuctionProps> = ({ id, lotId, collateralToken, en
       setIsClosed(json.value['is-accepted'].value);
     };
 
-    if (mounted) {
+    if (mounted && price !== 0 && discountedPrice !== 0) {
       void getData();
     }
 
     return () => { mounted = false; }
-  }, [price]);
+  }, [price, discountedPrice]);
 
   const setBidParams = () => {
     setBidAuctionId(id);

--- a/web/components/auction.tsx
+++ b/web/components/auction.tsx
@@ -20,7 +20,7 @@ export const Auction: React.FC<AuctionProps> = ({ id, lotId, collateralToken, en
     const fetchPrice = async () => {
       let price = await getPrice(collateralToken);
       setPrice(price);
-      setDiscountedPrice(price - (price * 0.03)); // TODO: change for discounted-auction-price on auction-engine SC
+      setDiscountedPrice(price - (price * 0.04)); // TODO: change for discounted-auction-price on auction-engine SC. 4% = 40% of 10% liquidation penalty
     };
 
     fetchPrice();

--- a/web/components/auction.tsx
+++ b/web/components/auction.tsx
@@ -20,6 +20,18 @@ export const Auction: React.FC<AuctionProps> = ({ id, lotId, collateralToken, en
     const fetchPrice = async () => {
       let price = await getPrice(collateralToken);
       setPrice(price);
+
+      const discountedPriceCall = await callReadOnlyFunction({
+        contractAddress,
+        contractName: "auction-engine",
+        functionName: "discounted-auction-price",
+        functionArgs: [uintCV(price), uintCV(id)],
+        senderAddress: stxAddress || '',
+        network: network,
+      });
+      console.log(discountedPriceCall);
+      const json = cvToJSON(discountedPriceCall);
+      console.log(json);
       setDiscountedPrice(price - (price * 0.04)); // TODO: change for discounted-auction-price on auction-engine SC. 4% = 40% of 10% liquidation penalty
     };
 

--- a/web/components/lot.tsx
+++ b/web/components/lot.tsx
@@ -21,6 +21,7 @@ export const Lot: React.FC<LotProps> = ({ id, lotId, collateralAmount, collatera
       contractName: 'auction-engine',
       functionName: 'redeem-lot-collateral',
       functionArgs: [
+        contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', 'freddie'),
         contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', token),
         contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', resolveReserveName(collateralToken.toLowerCase())),
         uintCV(id),

--- a/web/components/manage-vault.tsx
+++ b/web/components/manage-vault.tsx
@@ -96,7 +96,7 @@ export const ManageVault = ({ match }) => {
           url: json.value['url'].value,
           totalDebt: json.value['total-debt'].value,
           collateralToDebtRatio: json.value['collateral-to-debt-ratio'].value,
-          liquidationPenalty: json.value['liquidation-penalty'].value,
+          liquidationPenalty: json.value['liquidation-penalty'].value / 100,
           liquidationRatio: json.value['liquidation-ratio'].value,
           maximumDebt: json.value['maximum-debt'].value,
           stabilityFee: json.value['stability-fee'].value,


### PR DESCRIPTION
This refactors the liquidation penalty, with two stakeholders benefiting:

1. Protocol gets 60% of the liquidation penalty in the form of xUSD
2. Liquidator gets 40% of the liquidation penalty in the form of a discount on the price

60/40 is hardcoded right now.