### PR TITLE
test: add additional staking tests

### DIFF
--- a/clarity/tests/stake-registry_test.ts
+++ b/clarity/tests/stake-registry_test.ts
@@ -315,54 +315,127 @@ async fn(chain: Chain, accounts: Map<string, Account>) {
 });
 
 Clarinet.test({
-  name: "stake-registry: emergency withdraw",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
-    let deployer = accounts.get("deployer")!;
-    let wallet_1 = accounts.get("wallet_1")!;
-  
-    // Check DIKO and stDIKO balance before staking
-    let call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
-    call.result.expectOk().expectUint(150000000000);   
-    call = chain.callReadOnlyFn("stake-pool-diko", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
-    call.result.expectOk().expectUint(0);   
-  
-    // Staked total
-    call = chain.callReadOnlyFn("stake-pool-diko", "get-stake-amount-of", [types.principal(wallet_1.address)], wallet_1.address);
-    call.result.expectUint(0);
-    call = chain.callReadOnlyFn("stake-pool-diko", "get-total-staked", [], wallet_1.address);
-    call.result.expectUint(0);
-  
-    // Stake funds
-    let block = chain.mineBlock([
-      Tx.contractCall("stake-registry", "stake", [
-          types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stake-pool-diko'),
-          types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token'),
-          types.uint(100000000)
-      ], wallet_1.address)
-    ]);
-    block.receipts[0].result.expectOk().expectUint(100000000); // 10 with 6 decimals
-  
-    // Check DIKO and stDIKO balance after staking
-    call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
-    call.result.expectOk().expectUint(149900000000);   
-    call = chain.callReadOnlyFn("stake-pool-diko", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
-    call.result.expectOk().expectUint(100000000);   
-  
-    // Advance 3 block
-    chain.mineEmptyBlock(3);
-  
-    // Emergency withdraw
-    block = chain.mineBlock([
-      Tx.contractCall("stake-pool-diko", "emergency-withdraw", [], wallet_1.address)
-    ]);
-    block.receipts[0].result.expectOk().expectUint(0); 
+name: "stake-registry: emergency withdraw",
+async fn(chain: Chain, accounts: Map<string, Account>) {
+  let deployer = accounts.get("deployer")!;
+  let wallet_1 = accounts.get("wallet_1")!;
 
-    // Check DIKO and stDIKO balance after withdraw
-    call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
-    call.result.expectOk().expectUint(150000000000);   
-    call = chain.callReadOnlyFn("stake-pool-diko", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
-    call.result.expectOk().expectUint(0);  
+  // Check DIKO and stDIKO balance before staking
+  let call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(150000000000);   
+  call = chain.callReadOnlyFn("stake-pool-diko", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(0);   
 
-  }
-  });
+  // Staked total
+  call = chain.callReadOnlyFn("stake-pool-diko", "get-stake-amount-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectUint(0);
+  call = chain.callReadOnlyFn("stake-pool-diko", "get-total-staked", [], wallet_1.address);
+  call.result.expectUint(0);
 
+  // Stake funds
+  let block = chain.mineBlock([
+    Tx.contractCall("stake-registry", "stake", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stake-pool-diko'),
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token'),
+        types.uint(100000000)
+    ], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectOk().expectUint(100000000); // 10 with 6 decimals
+
+  // Check DIKO and stDIKO balance after staking
+  call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(149900000000);   
+  call = chain.callReadOnlyFn("stake-pool-diko", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(100000000);   
+
+  // Advance 3 block
+  chain.mineEmptyBlock(3);
+
+  // Emergency withdraw
+  block = chain.mineBlock([
+    Tx.contractCall("stake-pool-diko", "emergency-withdraw", [], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectOk().expectUint(0); 
+
+  // Check DIKO and stDIKO balance after withdraw
+  call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(150000000000);   
+  call = chain.callReadOnlyFn("stake-pool-diko", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(0);  
+
+}
+});
+
+Clarinet.test({
+name: "staking - try to stake more than balance",
+async fn(chain: Chain, accounts: Map<string, Account>) {
+  let deployer = accounts.get("deployer")!;
+  let wallet_1 = accounts.get("wallet_1")!;
+  let wallet_2 = accounts.get("wallet_2")!;
+
+  let call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(150000000000);   
+
+  // Stake
+  let block = chain.mineBlock([
+    Tx.contractCall("stake-registry", "stake", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stake-pool-diko'),
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token'),
+        types.uint(1500000000000)
+    ], wallet_1.address)
+  ]);
+  // https://docs.stacks.co/references/language-functions#ft-transfer
+  // 1 = not enough balance
+  block.receipts[0].result.expectErr().expectUint(1);
+}
+});
+
+Clarinet.test({
+name: "staking - claim without staking",
+async fn(chain: Chain, accounts: Map<string, Account>) {
+  let deployer = accounts.get("deployer")!;
+  let wallet_1 = accounts.get("wallet_1")!;
+  let wallet_2 = accounts.get("wallet_2")!;
+
+  // Claim
+  let block = chain.mineBlock([
+    Tx.contractCall("stake-registry", "claim-pending-rewards", [
+      types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stake-pool-diko')
+    ], wallet_1.address)
+  ]);
+  // No rewards
+  block.receipts[0].result.expectOk().expectUint(0);
+}
+});
+
+Clarinet.test({
+name: "staking - try to stake more than balance",
+async fn(chain: Chain, accounts: Map<string, Account>) {
+  let deployer = accounts.get("deployer")!;
+  let wallet_1 = accounts.get("wallet_1")!;
+  let wallet_2 = accounts.get("wallet_2")!;
+
+  let call = chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [types.principal(wallet_1.address)], wallet_1.address);
+  call.result.expectOk().expectUint(150000000000);   
+
+  // Stake
+  let block = chain.mineBlock([
+    Tx.contractCall("stake-registry", "stake", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stake-pool-diko'),
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token'),
+        types.uint(15000000000)
+    ], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectOk().expectUint(15000000000);
+
+  // Unstake funds
+  block = chain.mineBlock([
+    Tx.contractCall("stake-registry", "unstake", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.stake-pool-diko'),
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token'),
+        types.uint(25000000000)
+    ], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectErr().expectUint(18003);
+}
+});


### PR DESCRIPTION
Sad path tests:
- stake amount higher than wallet amount
- claim rewards for users without stake
- unstake more than stake
- stake/unstake 0
- stake and claim in same block
- can not unstake in pool directly

Contact changes:
- explicit error when trying to unstake more than staked (to prevent runtime error)