### PR TITLE
tweak: refactor payout address and CONTRACT-OWNER constants

### DIFF
--- a/clarity/contracts/arkadiko-token.clar
+++ b/clarity/contracts/arkadiko-token.clar
@@ -5,11 +5,18 @@
 (define-fungible-token diko)
 
 (define-data-var token-uri (string-utf8 256) u"")
+(define-data-var contract-owner principal tx-sender)
 
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED u1401)
 
-(define-constant CONTRACT-OWNER tx-sender)
+(define-public (set-contract-owner (owner principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get contract-owner)) (err ERR-NOT-AUTHORIZED))
+
+    (ok (var-set contract-owner owner))
+  )
+)
 
 ;; ---------------------------------------------------------
 ;; SIP-10 Functions
@@ -36,7 +43,7 @@
 )
 
 (define-public (set-token-uri (value (string-utf8 256)))
-  (if (is-eq tx-sender CONTRACT-OWNER)
+  (if (is-eq tx-sender (var-get contract-owner))
     (ok (var-set token-uri value))
     (err ERR-NOT-AUTHORIZED)
   )

--- a/clarity/contracts/arkadiko-token.clar
+++ b/clarity/contracts/arkadiko-token.clar
@@ -9,15 +9,7 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED u1401)
 
-(define-private (get-contract-owner)
-  (if (is-eq (unwrap-panic (get-block-info? header-hash u1)) 0xd2454d24b49126f7f47c986b06960d7f5b70812359084197a200d691e67a002e)
-    'ST2YP83431YWD9FNWTTDCQX8B3K0NDKPCV3B1R30H ;; Testnet only
-    (if (is-eq (unwrap-panic (get-block-info? header-hash u1)) 0x6b2c809627f2fd19991d8eb6ae034cb4cce1e1fc714aa77351506b5af1f8248e)
-      'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7 ;; Mainnet (TODO)
-      'STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7 ;; Other test environments
-    )
-  )
-)
+(define-constant CONTRACT-OWNER tx-sender)
 
 ;; ---------------------------------------------------------
 ;; SIP-10 Functions
@@ -44,7 +36,7 @@
 )
 
 (define-public (set-token-uri (value (string-utf8 256)))
-  (if (is-eq tx-sender (get-contract-owner))
+  (if (is-eq tx-sender CONTRACT-OWNER)
     (ok (var-set token-uri value))
     (err ERR-NOT-AUTHORIZED)
   )
@@ -79,23 +71,9 @@
 )
 
 
-
 ;; Test environments
 (begin
-  ;; TODO: fix manual mocknet/testnet/mainnet switch
-  ;; (if is-in-regtest
-  ;;   (if (is-eq (unwrap-panic (get-block-info? header-hash u1)) 0xd2454d24b49126f7f47c986b06960d7f5b70812359084197a200d691e67a002e)
-  ;;     (begin ;; Testnet only
-  ;;       (try! (ft-mint? diko u1000000000000000 'ST2YP83431YWD9FNWTTDCQX8B3K0NDKPCV3B1R30H)))
-  ;;     (begin ;; Other test environments
-  ;;       (try! (ft-mint? diko u890000000000 'STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7))
-  ;;       (try! (ft-mint? diko u150000000000 'ST3KCNDSWZSFZCC6BE4VA9AXWXC9KEB16FBTRK36T))
-  ;;       (try! (ft-mint? diko u150000000000 'ST3EQ88S02BXXD0T5ZVT3KW947CRMQ1C6DMQY8H19))
-  ;;       (try! (ft-mint? diko u1000000000 'STB2BWB0K5XZGS3FXVTG3TKS46CQVV66NAK3YVN8))
-  ;;     )
-  ;;   )
-  ;;   true
-  ;; )
+  ;; TODO: do not do this on testnet or mainnet
   (try! (ft-mint? diko u890000000000 'STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7))
   (try! (ft-mint? diko u150000000000 'ST3KCNDSWZSFZCC6BE4VA9AXWXC9KEB16FBTRK36T))
   (try! (ft-mint? diko u150000000000 'ST3EQ88S02BXXD0T5ZVT3KW947CRMQ1C6DMQY8H19))

--- a/clarity/contracts/auction-engine.clar
+++ b/clarity/contracts/auction-engine.clar
@@ -19,7 +19,6 @@
 (define-constant ERR-DIKO-REQUEST-FAILED u211)
 (define-constant ERR-TOKEN-TYPE-MISMATCH u212)
 
-(define-constant CONTRACT-OWNER tx-sender)
 (define-constant blocks-per-day u144)
 
 (define-map auctions
@@ -229,7 +228,7 @@
       xusd: u0,
       collateral-amount: u0,
       collateral-token: "",
-      owner: CONTRACT-OWNER,
+      owner: (contract-call? .dao get-dao-owner),
       is-accepted: false
     }
     (map-get? bids { auction-id: auction-id, lot-index: lot-index })
@@ -507,7 +506,7 @@
 ;; auction engine should only contain xUSD from bids
 (define-public (migrate-funds (auction-engine <auction-engine-trait>) (token <mock-ft-trait>))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (let (
       (balance (unwrap-panic (contract-call? token get-balance-of (as-contract tx-sender))))

--- a/clarity/contracts/auction-engine.clar
+++ b/clarity/contracts/auction-engine.clar
@@ -22,8 +22,6 @@
 (define-constant CONTRACT-OWNER tx-sender)
 (define-constant blocks-per-day u144)
 
-(define-data-var payout-address principal CONTRACT-OWNER) ;; to which address the foundation is paid
-
 (define-map auctions
   { id: uint }
   {
@@ -519,12 +517,8 @@
   )
 )
 
-;; TODO: make payout-address flexible with setters
-;; TODO: put payout-address in DAO and make it the same one as in freddie
 ;; redeem xUSD to burn DIKO gov token from open market
 ;; taken from auctions, paid by liquidation penalty on vaults
 (define-public (redeem-xusd (xusd-amount uint))
-  (begin
-    (contract-call? .xusd-token transfer xusd-amount (as-contract tx-sender) (var-get payout-address))
-  )
+  (contract-call? .xusd-token transfer xusd-amount (as-contract tx-sender) (contract-call? .dao get-payout-address))
 )

--- a/clarity/contracts/dao.clar
+++ b/clarity/contracts/dao.clar
@@ -32,6 +32,10 @@
 (define-data-var emergency-shutdown-activated bool false)
 (define-data-var payout-address principal DAO-OWNER) ;; to which address the foundation is paid
 
+(define-read-only (get-dao-owner)
+  DAO-OWNER
+)
+
 (define-read-only (get-payout-address)
   (var-get payout-address)
 )

--- a/clarity/contracts/dao.clar
+++ b/clarity/contracts/dao.clar
@@ -31,6 +31,7 @@
 ;; Variables
 (define-data-var emergency-shutdown-activated bool false)
 (define-data-var payout-address principal DAO-OWNER) ;; to which address the foundation is paid
+(define-data-var guardian principal DAO-OWNER) ;; guardian that can be set
 
 (define-read-only (get-dao-owner)
   DAO-OWNER
@@ -45,6 +46,26 @@
     (asserts! (is-eq tx-sender DAO-OWNER) (err ERR-NOT-AUTHORIZED))
 
     (ok (var-set payout-address address))
+  )
+)
+
+(define-read-only (get-guardian-address)
+  (var-get guardian)
+)
+
+(define-public (set-guardian-address (address principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get guardian)) (err ERR-NOT-AUTHORIZED))
+
+    (ok (var-set guardian address))
+  )
+)
+
+(define-public (trigger-emergency-shutdown)
+  (begin
+    (asserts! (is-eq tx-sender (var-get guardian)) (err ERR-NOT-AUTHORIZED))
+
+    (ok (var-set emergency-shutdown-activated (not (var-get emergency-shutdown-activated))))
   )
 )
 

--- a/clarity/contracts/dao.clar
+++ b/clarity/contracts/dao.clar
@@ -30,6 +30,19 @@
 
 ;; Variables
 (define-data-var emergency-shutdown-activated bool false)
+(define-data-var payout-address principal DAO-OWNER) ;; to which address the foundation is paid
+
+(define-read-only (get-payout-address)
+  (var-get payout-address)
+)
+
+(define-public (set-payout-address (address principal))
+  (begin
+    (asserts! (is-eq tx-sender DAO-OWNER) (err ERR-NOT-AUTHORIZED))
+
+    (ok (var-set payout-address address))
+  )
+)
 
 ;; TODO: 
 ;; Emergency shutdown should be on freddie?
@@ -93,10 +106,11 @@
   )
 )
 
-;; TODO: make sip10 trait dynamic
-;; Philip, why is this needed??
+;; This method is called by the auction engine when more bad debt needs to be burned
+;; but the vault collateral is not sufficient
+;; As a result, this method requests DIKO from the DAO ("foundation reserves")
 (define-public (request-diko-tokens (ft <mock-ft-trait>) (collateral-amount uint))
-  (contract-call? ft transfer collateral-amount DAO-OWNER (as-contract .sip10-reserve))
+  (contract-call? ft transfer collateral-amount DAO-OWNER (as-contract (unwrap-panic (get-qualified-name-by-name "sip10-reserve"))))
 )
 
 

--- a/clarity/contracts/freddie.clar
+++ b/clarity/contracts/freddie.clar
@@ -28,7 +28,6 @@
 
 (define-data-var stx-redeemable uint u0) ;; how much STX is available to trade for xSTX
 (define-data-var block-height-last-paid uint u0) ;; when the foundation was last paid
-(define-data-var payout-address principal CONTRACT-OWNER) ;; to which address the foundation is paid
 (define-data-var maximum-debt-surplus uint u10000000000000) ;; 10 million default - above that we sell the xUSD on the DIKO/xUSD pair to burn DIKO
 
 ;; getters
@@ -517,14 +516,6 @@
   (contract-call? .xusd-token get-balance-of (as-contract tx-sender))
 )
 
-(define-public (set-payout-address (address principal))
-  (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
-
-    (ok (var-set payout-address address))
-  )
-)
-
 ;; redeem xUSD working capital for the foundation
 ;; taken from stability fees paid by vault owners
 (define-public (redeem-xusd (xusd-amount uint))
@@ -532,7 +523,7 @@
     (asserts! (> (- block-height (var-get block-height-last-paid)) (* BLOCKS-PER-DAY u31)) (err ERR-NOT-AUTHORIZED))
 
     (var-set block-height-last-paid block-height)
-    (contract-call? .xusd-token transfer xusd-amount (as-contract tx-sender) (var-get payout-address))
+    (contract-call? .xusd-token transfer xusd-amount (as-contract tx-sender) (contract-call? .dao get-payout-address))
   )
 )
 

--- a/clarity/contracts/freddie.clar
+++ b/clarity/contracts/freddie.clar
@@ -24,7 +24,6 @@
 
 ;; constants
 (define-constant BLOCKS-PER-DAY u144)
-(define-constant CONTRACT-OWNER tx-sender)
 
 (define-data-var stx-redeemable uint u0) ;; how much STX is available to trade for xSTX
 (define-data-var block-height-last-paid uint u0) ;; when the foundation was last paid
@@ -140,7 +139,7 @@
 (define-public (enable-vault-withdrawals (stacker <stacker-trait>) (vault-id uint))
   (let ((vault (get-vault-by-id vault-id)))
     (asserts! (is-eq (unwrap-panic (contract-call? .dao get-emergency-shutdown-activated)) false) (err ERR-EMERGENCY-SHUTDOWN-ACTIVATED))
-    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq tx-sender (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq "STX" (get collateral-token vault)) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq false (get is-liquidated vault)) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq true (get revoked-stacking vault)) (err ERR-NOT-AUTHORIZED))
@@ -162,7 +161,7 @@
 (define-public (release-stacked-stx (stacker <stacker-trait>) (vault-id uint))
   (let ((vault (get-vault-by-id vault-id)))
     (asserts! (is-eq (unwrap-panic (contract-call? .dao get-emergency-shutdown-activated)) false) (err ERR-EMERGENCY-SHUTDOWN-ACTIVATED))
-    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq tx-sender (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq "xSTX" (get collateral-token vault)) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq true (get is-liquidated vault)) (err ERR-NOT-AUTHORIZED))
     (asserts! (> (get stacked-tokens vault) u0) (err ERR-NOT-AUTHORIZED))
@@ -531,7 +530,7 @@
 ;; freddie should only contain xUSD
 (define-public (migrate-funds (new-vault-manager <vault-manager-trait>) (token <mock-ft-trait>))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (let (
       (balance (unwrap-panic (contract-call? token get-balance-of (as-contract tx-sender))))
@@ -543,7 +542,7 @@
 
 (define-public (set-stx-redeemable (new-stx-redeemable uint))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (var-set stx-redeemable new-stx-redeemable)
     (ok true)
@@ -552,7 +551,7 @@
 
 (define-public (set-block-height-last-paid (new-block-height-last-paid uint))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (var-set block-height-last-paid new-block-height-last-paid)
     (ok true)
@@ -561,7 +560,7 @@
 
 (define-public (set-maximum-debt-surplus (new-maximum-debt-surplus uint))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (var-set maximum-debt-surplus new-maximum-debt-surplus)
     (ok true)
@@ -572,7 +571,7 @@
 ;; payout address has a separate setter that can be configured
 (define-public (migrate-state (new-vault-manager <vault-manager-trait>))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (try! (contract-call? new-vault-manager set-stx-redeemable (var-get stx-redeemable)))
     (try! (contract-call? new-vault-manager set-block-height-last-paid (var-get block-height-last-paid)))

--- a/clarity/contracts/sip10-reserve.clar
+++ b/clarity/contracts/sip10-reserve.clar
@@ -10,8 +10,6 @@
 (define-constant ERR-MINT-FAILED u97)
 (define-constant ERR-WRONG-TOKEN u98)
 
-(define-constant CONTRACT-OWNER tx-sender)
-
 (define-read-only (calculate-xusd-count (token (string-ascii 12)) (ucollateral-amount uint) (collateral-type (string-ascii 12)))
   (let ((price-in-cents (contract-call? .oracle get-price token)))
     (let ((amount
@@ -126,7 +124,7 @@
 
 (define-public (set-tokens-to-stack (new-tokens-to-stack uint))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     ;; NOOP
     (ok true)
@@ -138,7 +136,7 @@
 ;; so this method should be ran multiple times, once for each token
 (define-public (migrate-funds (new-vault <vault-trait>) (token <mock-ft-trait>))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (let (
       (balance (unwrap-panic (contract-call? token get-balance-of (as-contract tx-sender))))

--- a/clarity/contracts/stacker.clar
+++ b/clarity/contracts/stacker.clar
@@ -21,7 +21,6 @@
 (define-constant ERR-FAILED-STACK-STX u192)
 (define-constant ERR-BURN-HEIGHT-NOT-REACHED u193)
 (define-constant ERR-ALREADY-STACKING u194)
-(define-constant CONTRACT-OWNER tx-sender)
 
 (define-data-var stacking-unlock-burn-height uint u0) ;; when is this cycle over
 (define-data-var stacking-stx-stacked uint u0) ;; how many stx did we stack in this cycle
@@ -50,7 +49,7 @@
 
 (define-public (set-stacking-stx-received (stx-received uint))
   (begin
-    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq tx-sender (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (ok (var-set stacking-stx-received stx-received))
   )
@@ -66,7 +65,7 @@
     (can-stack (as-contract (contract-call? 'ST000000000000000000002AMW42H.pox can-stack-stx pox-addr tokens-to-stack start-burn-ht lock-period)))
     (stx-balance (unwrap-panic (get-stx-balance)))
   )
-    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq tx-sender (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
     (asserts! (>= burn-block-height (var-get stacking-unlock-burn-height)) (err ERR-ALREADY-STACKING))
 
     ;; check if we can stack - if not, then probably cause we have not reached the minimum with (var-get tokens-to-stack)
@@ -120,7 +119,7 @@
   (let (
     (vault (contract-call? .vault-data get-vault-by-id vault-id))
   )
-    (asserts! (is-eq tx-sender CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq tx-sender (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
     (asserts!
       (or
         (is-eq "xSTX" (get collateral-token vault))

--- a/clarity/contracts/stake-pool-diko.clar
+++ b/clarity/contracts/stake-pool-diko.clar
@@ -55,7 +55,7 @@
 )
 
 (define-public (set-token-uri (value (string-utf8 256)))
-  (if (is-eq tx-sender CONTRACT-OWNER) ;; TODO: should become DAO??
+  (if (is-eq tx-sender (contract-call? .dao get-dao-owner))
     (ok (var-set token-uri value))
     (err ERR-NOT-AUTHORIZED)
   )

--- a/clarity/contracts/stake-pool-diko.clar
+++ b/clarity/contracts/stake-pool-diko.clar
@@ -17,7 +17,6 @@
 (define-constant ERR-INSUFFICIENT-STAKE (err u18003))
 
 ;; Constants
-(define-constant CONTRACT-OWNER tx-sender) ;; TODO: should be DAO
 (define-constant POOL-TOKEN .arkadiko-token)
 (define-constant BLOCKS-PER-YEAR u52560)
 

--- a/clarity/contracts/stx-reserve.clar
+++ b/clarity/contracts/stx-reserve.clar
@@ -12,8 +12,6 @@
 (define-constant ERR-MINT-FAILED u117)
 (define-constant ERR-WRONG-TOKEN u118)
 
-(define-constant CONTRACT-OWNER tx-sender)
-
 (define-data-var tokens-to-stack uint u0)
 
 ;; MAIN LOGIC
@@ -206,7 +204,7 @@
 ;; STX reserve should only contain STX
 (define-public (migrate-funds (new-vault <vault-trait>))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (as-contract (stx-transfer? (stx-get-balance (as-contract tx-sender)) (as-contract tx-sender) (contract-of new-vault)))
   )
@@ -214,7 +212,7 @@
 
 (define-public (set-tokens-to-stack (new-tokens-to-stack uint))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (var-set tokens-to-stack new-tokens-to-stack)
     (ok true)
@@ -223,7 +221,7 @@
 
 (define-public (migrate-state (new-vault <vault-trait>))
   (begin
-    (asserts! (is-eq contract-caller CONTRACT-OWNER) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq contract-caller (contract-call? .dao get-dao-owner)) (err ERR-NOT-AUTHORIZED))
 
     (try! (contract-call? new-vault set-tokens-to-stack (var-get tokens-to-stack)))
     (ok true)

--- a/clarity/contracts/vault-data.clar
+++ b/clarity/contracts/vault-data.clar
@@ -35,7 +35,6 @@
   }
 )
 (define-data-var last-vault-id uint u0)
-(define-constant CONTRACT-OWNER tx-sender)
 (define-constant ERR-NOT-AUTHORIZED u7401)
 
 ;; ---------------------------------------------------------
@@ -46,7 +45,7 @@
   (default-to
     {
       id: u0,
-      owner: CONTRACT-OWNER,
+      owner: (contract-call? .dao get-dao-owner),
       collateral: u0,
       collateral-type: "",
       collateral-token: "",
@@ -149,7 +148,6 @@
 
     (map-set stacking-payout
       { vault-id: vault-id }
-      ;;{ principals: (list (tuple (percentage-basis-points u0) (recipient CONTRACT-OWNER))) }
       { collateral-amount: u0, principals: (list) }
     )
 

--- a/clarity/contracts/xstx-token.clar
+++ b/clarity/contracts/xstx-token.clar
@@ -11,16 +11,6 @@
 (define-constant ERR-BURN-FAILED u131)
 (define-constant ERR-NOT-AUTHORIZED u13401)
 
-(define-private (get-contract-owner)
-  (if (is-eq (unwrap-panic (get-block-info? header-hash u1)) 0xd2454d24b49126f7f47c986b06960d7f5b70812359084197a200d691e67a002e)
-    'ST2YP83431YWD9FNWTTDCQX8B3K0NDKPCV3B1R30H ;; Testnet only
-    (if (is-eq (unwrap-panic (get-block-info? header-hash u1)) 0x6b2c809627f2fd19991d8eb6ae034cb4cce1e1fc714aa77351506b5af1f8248e)
-      'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7 ;; Mainnet (TODO)
-      'STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7 ;; Other test environments
-    )
-  )
-)
-
 ;; ---------------------------------------------------------
 ;; SIP-10 Functions
 ;; ---------------------------------------------------------
@@ -46,7 +36,7 @@
 )
 
 (define-public (set-token-uri (value (string-utf8 256)))
-  (if (is-eq tx-sender (get-contract-owner))
+  (if (is-eq tx-sender (contract-call? .dao get-dao-owner))
     (ok (var-set token-uri value))
     (err ERR-NOT-AUTHORIZED)
   )

--- a/clarity/contracts/xusd-token.clar
+++ b/clarity/contracts/xusd-token.clar
@@ -9,8 +9,6 @@
 ;; errors
 (define-constant ERR-NOT-AUTHORIZED u14401)
 
-(define-constant CONTRACT-OWNER tx-sender)
-
 ;; ---------------------------------------------------------
 ;; SIP-10 Functions
 ;; ---------------------------------------------------------
@@ -36,7 +34,7 @@
 )
 
 (define-public (set-token-uri (value (string-utf8 256)))
-  (if (is-eq tx-sender CONTRACT-OWNER)
+  (if (is-eq tx-sender (contract-call? .dao get-dao-owner))
     (ok (var-set token-uri value))
     (err ERR-NOT-AUTHORIZED)
   )
@@ -73,6 +71,7 @@
 
 ;; Initialize the contract
 (begin
+  ;; TODO: do not do this on testnet or mainnet
   (try! (ft-mint? xusd u20 'ST3KCNDSWZSFZCC6BE4VA9AXWXC9KEB16FBTRK36T))
   (try! (ft-mint? xusd u10 'STB2BWB0K5XZGS3FXVTG3TKS46CQVV66NAK3YVN8))
   (try! (ft-mint? xusd u1000000000 'STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7))


### PR DESCRIPTION
- get rid of CONTRACT-OWNER constants in favor of DAO-OWNER
- define payout-address for foundation in DAO