### PR TITLE
[1] Refactor auction to remove external call

### DIFF
--- a/clarity/contracts/arkadiko-auction-engine-v1-1.clar
+++ b/clarity/contracts/arkadiko-auction-engine-v1-1.clar
@@ -416,6 +416,19 @@
   )
 )
 
+(define-private (remove-winning-lot (lot (tuple (auction-id uint) (lot-index uint))))
+  (let ((current-lot (unwrap-panic (map-get? redeeming-lot { user: tx-sender }))))
+    (if 
+      (and
+        (is-eq (get auction-id lot) (get auction-id current-lot))
+        (is-eq (get lot-index lot) (get lot-index current-lot))
+      )
+      false
+      true
+    )
+  )
+)
+
 (define-private (return-xusd (owner principal) (xusd uint) (auction-id uint) (lot-index uint))
   (if (> xusd u0)
     (let ((lots (get-winning-lots tx-sender)))

--- a/clarity/contracts/arkadiko-auction-engine-v1-1.clar
+++ b/clarity/contracts/arkadiko-auction-engine-v1-1.clar
@@ -349,7 +349,7 @@
     )
 
     ;; Set stacker payout
-    (try! (contract-call? .arkadiko-vault-data-v1-1 add-stacker-payout (get vault-id auction) collateral-amount tx-sender))
+    (try! (contract-call? .arkadiko-vault-data-v1-1 set-stacker-payout (get vault-id auction) lot-index collateral-amount tx-sender))
     (print { type: "bid", action: "registered", data: { auction-id: auction-id, lot-index: lot-index, xusd: xusd } })
 
     ;; End auction if needed

--- a/clarity/contracts/arkadiko-auction-engine-v1-1.clar
+++ b/clarity/contracts/arkadiko-auction-engine-v1-1.clar
@@ -92,6 +92,10 @@
   )
 )
 
+;; (define-read-only (get-bids (auction-id uint))
+
+;; )
+
 ;; Check if auction open (not enough dept raised + end block height not reached)
 (define-read-only (get-auction-open (auction-id uint))
   (let (

--- a/clarity/contracts/arkadiko-auction-engine-v1-1.clar
+++ b/clarity/contracts/arkadiko-auction-engine-v1-1.clar
@@ -371,8 +371,16 @@
   (let (
     (last-bid (get-last-bid auction-id lot-index))
     (auction (get-auction-by-id auction-id))
+    (token-string (get collateral-token auction))
   )
-    (asserts! (is-eq (unwrap-panic (contract-call? ft get-symbol)) (get collateral-token auction)) (err ERR-TOKEN-TYPE-MISMATCH))
+    (asserts!
+      (or
+        (is-eq (unwrap-panic (contract-call? ft get-symbol)) token-string)
+        (is-eq "STX" token-string)
+        (is-eq "xSTX" token-string)
+      )
+      (err ERR-TOKEN-TYPE-MISMATCH)
+    )
     (asserts! (is-eq (contract-of vault-manager) (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "freddie"))) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq tx-sender (get owner last-bid)) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq (unwrap-panic (get-auction-open auction-id)) false) (err ERR-AUCTION-NOT-CLOSED))

--- a/clarity/contracts/arkadiko-auction-engine-v1-1.clar
+++ b/clarity/contracts/arkadiko-auction-engine-v1-1.clar
@@ -406,9 +406,9 @@
       ;; request "collateral-amount" gov tokens from the DAO
       (begin
         (try! (contract-call? .arkadiko-dao request-diko-tokens ft (get collateral-amount auction)))
-        (try! (contract-call? vault-manager redeem-auction-collateral ft reserve (get collateral-amount last-bid) tx-sender))
+        (try! (contract-call? vault-manager redeem-auction-collateral ft token-string reserve (get collateral-amount last-bid) tx-sender))
       )
-      (try! (contract-call? vault-manager redeem-auction-collateral ft reserve (get collateral-amount last-bid) tx-sender))
+      (try! (contract-call? vault-manager redeem-auction-collateral ft token-string reserve (get collateral-amount last-bid) tx-sender))
     )
     (print { type: "lot", action: "redeemed", data: { auction-id: auction-id, lot-index: lot-index } })
     (ok true)

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -80,9 +80,9 @@
             (ok
               (/
                 (* (get collateral vault) (get last-price-in-cents stx-price-in-cents))
-                ;; (get debt vault)
+                (get debt vault)
                 ;; TODO: cost is too high to use this in the front-end - fix this
-                (+ (get debt vault) (unwrap-panic (get-stability-fee-for-vault vault-id)))
+                ;; (+ (get debt vault) (unwrap-panic (get-stability-fee-for-vault vault-id)))
               )
             )
             (err u0)

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -76,6 +76,12 @@
   )
 )
 
+(define-read-only (get-collateral-token-for-vault (vault-id uint))
+  (let ((vault (get-vault-by-id vault-id)))
+    (ok (get collateral-token vault))
+  )
+)
+
 (define-read-only (calculate-current-collateral-to-debt-ratio (vault-id uint))
   (let ((vault (get-vault-by-id vault-id)))
     (if (is-eq (get is-liquidated vault) true)
@@ -258,16 +264,18 @@
   )
 )
 
+
+
 (define-public (collateralize-and-mint
     (collateral-amount uint)
     (debt uint)
-    (sender principal)
     (collateral-type (string-ascii 12))
-    (collateral-token (string-ascii 12))
     (reserve <vault-trait>)
     (ft <mock-ft-trait>)
   )
   (let (
+    (sender tx-sender)
+    (collateral-token (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name collateral-type))))
     (ratio (unwrap! (contract-call? reserve calculate-current-collateral-to-debt-ratio collateral-token debt collateral-amount) (err ERR-WRONG-DEBT)))
   )
     (asserts!
@@ -277,8 +285,6 @@
       )
       (err ERR-EMERGENCY-SHUTDOWN-ACTIVATED)
     )
-    (asserts! (is-eq tx-sender sender) (err ERR-NOT-AUTHORIZED))
-    (asserts! (> collateral-amount u0) (err ERR-INSUFFICIENT-COLLATERAL))
     (asserts! (>= ratio (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-liquidation-ratio collateral-type))) (err ERR-INSUFFICIENT-COLLATERAL))
     (asserts!
       (<
@@ -288,7 +294,7 @@
       (err ERR-MAXIMUM-DEBT-REACHED)
     )
 
-    (try! (contract-call? reserve collateralize-and-mint ft collateral-token collateral-type collateral-amount debt sender))
+    (try! (contract-call? reserve collateralize-and-mint ft collateral-token collateral-amount debt sender))
     (try! (as-contract (contract-call? .arkadiko-dao mint-token .xusd-token debt sender)))
     (let (
       (vault-id (+ (contract-call? .arkadiko-vault-data-v1-1 get-last-vault-id) u1))
@@ -324,6 +330,7 @@
 (define-public (deposit (vault-id uint) (uamount uint) (reserve <vault-trait>) (ft <mock-ft-trait>))
   (let (
     (vault (get-vault-by-id vault-id))
+    (collateral-token (unwrap-panic (get-collateral-token-for-vault vault-id)))
     (new-collateral (+ uamount (get collateral vault)))
     (updated-vault (merge vault {
       collateral: new-collateral,
@@ -339,7 +346,7 @@
     )
     (asserts! (is-eq (get is-liquidated vault) false) (err ERR-VAULT-LIQUIDATED))
 
-    (unwrap! (contract-call? reserve deposit ft uamount) (err ERR-DEPOSIT-FAILED))
+    (unwrap! (contract-call? reserve deposit ft collateral-token uamount) (err ERR-DEPOSIT-FAILED))
     (try! (contract-call? .arkadiko-vault-data-v1-1 update-vault vault-id updated-vault))
     (try! (contract-call? .arkadiko-vault-rewards-v1-1 add-collateral uamount (get owner vault)))
     (print { type: "vault", action: "deposit", data: updated-vault })
@@ -348,7 +355,10 @@
 )
 
 (define-public (withdraw (vault-id uint) (uamount uint) (reserve <vault-trait>) (ft <mock-ft-trait>))
-  (let ((vault (get-vault-by-id vault-id)))
+  (let (
+    (vault (get-vault-by-id vault-id))
+    (collateral-token (unwrap-panic (get-collateral-token-for-vault vault-id)))
+  )
     (asserts!
       (and
         (is-eq (unwrap-panic (contract-call? .arkadiko-dao get-emergency-shutdown-activated)) false)
@@ -376,7 +386,7 @@
           })))
       ;; TODO: FIX (make "STX" dynamic)
       (asserts! (>= ratio (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-to-debt-ratio (get collateral-type vault)))) (err ERR-INSUFFICIENT-COLLATERAL))
-      (unwrap! (contract-call? reserve withdraw ft (get owner vault) uamount) (err ERR-WITHDRAW-FAILED))
+      (unwrap! (contract-call? reserve withdraw ft collateral-token (get owner vault) uamount) (err ERR-WITHDRAW-FAILED))
       (try! (contract-call? .arkadiko-vault-data-v1-1 update-vault vault-id updated-vault))
       (try! (contract-call? .arkadiko-vault-rewards-v1-1 remove-collateral uamount (get owner vault)))
       (print { type: "vault", action: "withdraw", data: updated-vault })
@@ -538,6 +548,7 @@
     )
     (asserts! (is-eq contract-caller .arkadiko-liquidator-v1-1) (err ERR-NOT-AUTHORIZED))
 
+    (try! (contract-call? .arkadiko-vault-rewards-v1-1 claim-pending-rewards-liquidated-vault (get owner vault)))
     (let (
       (collateral (get collateral vault))
       (liquidation-penalty (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-liquidation-penalty (get collateral-type vault))))
@@ -606,12 +617,18 @@
   )
 )
 
-(define-public (redeem-auction-collateral (ft <mock-ft-trait>) (reserve <vault-trait>) (collateral-amount uint) (sender principal))
-  (contract-call? reserve redeem-collateral ft collateral-amount sender)
+(define-public (redeem-auction-collateral (ft <mock-ft-trait>) (token-string (string-ascii 12)) (reserve <vault-trait>) (collateral-amount uint) (sender principal))
+  (begin
+    (asserts! (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "auction-engine"))) (err ERR-NOT-AUTHORIZED))
+    (contract-call? reserve redeem-collateral ft token-string collateral-amount sender)
+  )
 )
 
 (define-public (withdraw-leftover-collateral (vault-id uint) (reserve <vault-trait>) (ft <mock-ft-trait>))
-  (let ((vault (get-vault-by-id vault-id)))
+  (let (
+    (vault (get-vault-by-id vault-id))
+    (collateral-token (unwrap-panic (get-collateral-token-for-vault vault-id)))
+  )
     (asserts!
       (and
         (is-eq (unwrap-panic (contract-call? .arkadiko-dao get-emergency-shutdown-activated)) false)
@@ -623,7 +640,7 @@
     (asserts! (is-eq true (get is-liquidated vault)) (err ERR-VAULT-NOT-LIQUIDATED))
     (asserts! (is-eq true (get auction-ended vault)) (err ERR-AUCTION-NOT-ENDED))
 
-    (if (unwrap-panic (contract-call? reserve withdraw ft (get owner vault) (get leftover-collateral vault)))
+    (if (unwrap-panic (contract-call? reserve withdraw ft collateral-token (get owner vault) (get leftover-collateral vault)))
       (begin
         (try! (contract-call? .arkadiko-vault-data-v1-1 update-vault vault-id (merge vault {
             updated-at-block-height: block-height,
@@ -646,14 +663,28 @@
   (contract-call? .xusd-token get-balance-of (as-contract tx-sender))
 )
 
-;; redeem xUSD working capital for the foundation
+(define-read-only (get-diko-balance)
+  (contract-call? .arkadiko-token get-balance-of (as-contract tx-sender))
+)
+
+;; redeem xUSD and DIKO working capital for the foundation
 ;; taken from stability fees paid by vault owners
-(define-public (redeem-xusd (xusd-amount uint))
+(define-public (redeem-tokens (xusd-amount uint) (diko-amount uint))
   (begin
     (asserts! (> (- block-height (var-get block-height-last-paid)) (* BLOCKS-PER-DAY u31)) (err ERR-NOT-AUTHORIZED))
 
     (var-set block-height-last-paid block-height)
-    (contract-call? .xusd-token transfer xusd-amount (as-contract tx-sender) (contract-call? .arkadiko-dao get-payout-address))
+
+    (if (and (> xusd-amount u0) (> diko-amount u0))
+      (begin
+        (try! (contract-call? .arkadiko-token transfer diko-amount (as-contract tx-sender) (contract-call? .arkadiko-dao get-payout-address)))
+        (contract-call? .xusd-token transfer xusd-amount (as-contract tx-sender) (contract-call? .arkadiko-dao get-payout-address))
+      )
+      (if (> xusd-amount u0)
+        (contract-call? .xusd-token transfer xusd-amount (as-contract tx-sender) (contract-call? .arkadiko-dao get-payout-address))
+        (contract-call? .arkadiko-token transfer diko-amount (as-contract tx-sender) (contract-call? .arkadiko-dao get-payout-address))
+      )
+    )
   )
 )
 

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -80,9 +80,9 @@
             (ok
               (/
                 (* (get collateral vault) (get last-price-in-cents stx-price-in-cents))
-                (get debt vault)
+                ;; (get debt vault)
                 ;; TODO: cost is too high to use this in the front-end - fix this
-                ;; (+ (get debt vault) (unwrap-panic (get-stability-fee-for-vault vault-id)))
+                (+ (get debt vault) (unwrap-panic (get-stability-fee-for-vault vault-id)))
               )
             )
             (err u0)
@@ -529,7 +529,6 @@
     )
     (asserts! (is-eq contract-caller .arkadiko-liquidator-v1-1) (err ERR-NOT-AUTHORIZED))
 
-    (try! (contract-call? .arkadiko-vault-data-v1-1 reset-stacking-payouts vault-id))
     (let (
       (collateral (get collateral vault))
       (liquidation-penalty (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-liquidation-penalty (get collateral-type vault))))

--- a/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
@@ -33,11 +33,13 @@
 )
 
 ;; (match (print (ft-transfer? token ucollateral-amount sender (as-contract tx-sender)))
-(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (type (string-ascii 12)) (ucollateral-amount uint) (debt uint) (sender principal))
-  (let ((token-symbol (unwrap-panic (contract-call? token get-symbol))))
+(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (ucollateral-amount uint) (debt uint) (sender principal))
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
-    (asserts! (is-eq (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name type))) token-symbol) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
 
     ;; token should be a trait e.g. 'SP3GWX3NE58KXHESRYE4DYQ1S31PQJTCRXB3PE9SB.arkadiko-token
     (match (contract-call? token transfer ucollateral-amount sender (as-contract tx-sender))
@@ -47,9 +49,13 @@
   )
 )
 
-(define-public (deposit (token <mock-ft-trait>) (additional-ucollateral-amount uint))
-  (begin
+(define-public (deposit (token <mock-ft-trait>) (token-string (string-ascii 12)) (additional-ucollateral-amount uint))
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
 
     (match (contract-call? token transfer additional-ucollateral-amount tx-sender (as-contract tx-sender))
       success (ok true)
@@ -58,9 +64,13 @@
   )
 )
 
-(define-public (withdraw (token <mock-ft-trait>) (vault-owner principal) (ucollateral-amount uint))
-  (begin
+(define-public (withdraw (token <mock-ft-trait>) (token-string (string-ascii 12)) (vault-owner principal) (ucollateral-amount uint))
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
 
     (match (as-contract (contract-call? token transfer ucollateral-amount (as-contract tx-sender) vault-owner))
       success (ok true)
@@ -69,11 +79,12 @@
   )
 )
 
-(define-public (mint (token (string-ascii 12)) (vault-owner principal) (ucollateral-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
+(define-public (mint (token-string (string-ascii 12)) (vault-owner principal) (ucollateral-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
 
-    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token ucollateral-amount collateral-type)) current-debt)))
+    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token-string ucollateral-amount collateral-type)) current-debt)))
       (if (>= max-new-debt extra-debt)
         (match (as-contract (contract-call? .arkadiko-dao mint-token .xusd-token extra-debt vault-owner))
           success (ok true)
@@ -86,8 +97,11 @@
 )
 
 (define-public (burn (token <mock-ft-trait>) (vault-owner principal) (collateral-to-return uint))
-  (begin
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
 
     (match (as-contract (contract-call? token transfer collateral-to-return (as-contract tx-sender) vault-owner))
       transferred (ok true)
@@ -96,9 +110,14 @@
   )
 )
 
-(define-public (redeem-collateral (token <mock-ft-trait>) (ucollateral uint) (owner principal))
-  (begin
+(define-public (redeem-collateral (token <mock-ft-trait>) (token-string (string-ascii 12)) (ucollateral uint) (owner principal))
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
+    
     (as-contract (contract-call? token transfer ucollateral (as-contract tx-sender) owner))
   )
 )

--- a/clarity/contracts/arkadiko-stacker-v1-1.clar
+++ b/clarity/contracts/arkadiko-stacker-v1-1.clar
@@ -26,7 +26,7 @@
 (define-data-var stacking-unlock-burn-height uint u0) ;; when is this cycle over
 (define-data-var stacking-stx-stacked uint u0) ;; how many stx did we stack in this cycle
 (define-data-var stacking-stx-received uint u0) ;; how many btc did we convert into STX tokens to add to vault collateral
-(define-data-var stacking-stx-in-vault uint u0)
+(define-data-var payout-vault-id uint u0)
 (define-data-var stacker-shutdown-activated bool false)
 
 (define-data-var stacker-yield uint u9000) ;; 90%
@@ -184,27 +184,30 @@
 (define-private (payout-liquidated-vault (vault-id uint))
   (let (
     (vault (contract-call? .arkadiko-vault-data-v1-1 get-vault-by-id vault-id))
-    (stacking-entry (contract-call? .arkadiko-vault-data-v1-1 get-stacking-payout vault-id))
+    ;; (stacking-entry (contract-call? .arkadiko-vault-data-v1-1 get-stacking-payout vault-id u0))
+    (stacking-lots (contract-call? .arkadiko-vault-data-v1-1 get-stacking-payout-lots vault-id))
   )
     (asserts! (is-eq (get is-liquidated vault) true) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq (get auction-ended vault) true) (err ERR-NOT-AUTHORIZED))
     (asserts! (> (get stacked-tokens vault) u0) (err ERR-NOT-AUTHORIZED))
 
-    (var-set stacking-stx-in-vault (get collateral-amount stacking-entry))
-    (map payout-lot-bidder (get principals stacking-entry))
+    (var-set payout-vault-id (get id vault))
+    (map payout-lot-bidder (get ids stacking-lots))
     (ok true)
   )
 )
 
-(define-private (payout-lot-bidder (data (tuple (collateral-amount uint) (recipient principal))))
+(define-private (payout-lot-bidder (lot-index uint))
   (let (
-    (stx-in-vault (var-get stacking-stx-in-vault))
-    (percentage (/ (* u100000 (get collateral-amount data)) stx-in-vault)) ;; in basis points
+    (vault (contract-call? .arkadiko-vault-data-v1-1 get-vault-by-id (var-get payout-vault-id)))
+    (stx-in-vault (get stacked-tokens vault))
+    (stacker-payout (contract-call? .arkadiko-vault-data-v1-1 get-stacking-payout (get id vault) lot-index))
+    (percentage (/ (* u100000 (get collateral-amount stacker-payout)) stx-in-vault)) ;; in basis points
     (basis-points (/ (* u100000 stx-in-vault) (var-get stacking-stx-stacked))) ;; this gives the percentage of collateral bought in auctions vs stx stacked
     (earned-amount-vault (/ (* (var-get stacking-stx-received) basis-points) u100000))
     (earned-amount-bidder (/ (* percentage earned-amount-vault) u100000))
   )
-    (try! (as-contract (stx-transfer? earned-amount-bidder (as-contract tx-sender) (get recipient data))))
+    (try! (as-contract (stx-transfer? earned-amount-bidder (as-contract tx-sender) (get principal stacker-payout))))
     (ok true)
   )
 )

--- a/clarity/contracts/arkadiko-stacker-v1-1.clar
+++ b/clarity/contracts/arkadiko-stacker-v1-1.clar
@@ -184,7 +184,6 @@
 (define-private (payout-liquidated-vault (vault-id uint))
   (let (
     (vault (contract-call? .arkadiko-vault-data-v1-1 get-vault-by-id vault-id))
-    ;; (stacking-entry (contract-call? .arkadiko-vault-data-v1-1 get-stacking-payout vault-id u0))
     (stacking-lots (contract-call? .arkadiko-vault-data-v1-1 get-stacking-payout-lots vault-id))
   )
     (asserts! (is-eq (get is-liquidated vault) true) (err ERR-NOT-AUTHORIZED))
@@ -200,7 +199,7 @@
 (define-private (payout-lot-bidder (lot-index uint))
   (let (
     (vault (contract-call? .arkadiko-vault-data-v1-1 get-vault-by-id (var-get payout-vault-id)))
-    (stx-in-vault (get stacked-tokens vault))
+    (stx-in-vault (- (get stacked-tokens vault) (/ (get stacked-tokens vault) u10))) ;; we keep 10%
     (stacker-payout (contract-call? .arkadiko-vault-data-v1-1 get-stacking-payout (get id vault) lot-index))
     (percentage (/ (* u100000 (get collateral-amount stacker-payout)) stx-in-vault)) ;; in basis points
     (basis-points (/ (* u100000 stx-in-vault) (var-get stacking-stx-stacked))) ;; this gives the percentage of collateral bought in auctions vs stx stacked

--- a/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
@@ -89,11 +89,10 @@
 ;; accept collateral in STX tokens
 ;; save STX in stx-reserve-address
 ;; calculate price and collateralisation ratio
-(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (type (string-ascii 12)) (ustx-amount uint) (debt uint) (sender principal))
+(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (ustx-amount uint) (debt uint) (sender principal))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
-    (asserts! (is-eq (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name type))) "STX") (err ERR-WRONG-TOKEN))
 
     (match (print (stx-transfer? ustx-amount sender (as-contract tx-sender)))
       success (begin
@@ -106,9 +105,10 @@
 )
 
 ;; deposit extra collateral in vault
-(define-public (deposit (token <mock-ft-trait>) (additional-ustx-amount uint))
+(define-public (deposit (token <mock-ft-trait>) (token-string (string-ascii 12)) (additional-ustx-amount uint))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
 
     (match (print (stx-transfer? additional-ustx-amount tx-sender (as-contract tx-sender)))
       success (begin
@@ -121,9 +121,10 @@
 )
 
 ;; withdraw collateral (e.g. if collateral goes up in value)
-(define-public (withdraw (token <mock-ft-trait>) (vault-owner principal) (ustx-amount uint))
+(define-public (withdraw (token <mock-ft-trait>) (token-string (string-ascii 12)) (vault-owner principal) (ustx-amount uint))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
 
     (match (print (as-contract (stx-transfer? ustx-amount (as-contract tx-sender) vault-owner)))
       success (ok true)
@@ -133,11 +134,12 @@
 )
 
 ;; mint new tokens when collateral to debt allows it (i.e. > collateral-to-debt-ratio)
-(define-public (mint (token (string-ascii 12)) (vault-owner principal) (ustx-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
+(define-public (mint (token-string (string-ascii 12)) (vault-owner principal) (ustx-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
 
-    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token ustx-amount collateral-type)) current-debt)))
+    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token-string ustx-amount collateral-type)) current-debt)))
       (if (>= max-new-debt extra-debt)
         (match (print (as-contract (contract-call? .arkadiko-dao mint-token .xusd-token extra-debt vault-owner)))
           success (ok true)
@@ -179,9 +181,11 @@
   )
 )
 
-(define-public (redeem-collateral (token <mock-ft-trait>) (stx-collateral uint) (owner principal))
+(define-public (redeem-collateral (token <mock-ft-trait>) (token-string (string-ascii 12)) (stx-collateral uint) (owner principal))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
+
     (as-contract (stx-transfer? stx-collateral (as-contract tx-sender) owner))
   )
 )

--- a/clarity/contracts/arkadiko-vault-data-v1-1.clar
+++ b/clarity/contracts/arkadiko-vault-data-v1-1.clar
@@ -168,7 +168,10 @@
         principal: recipient
       }
     )
-    (map-set stacking-payout-lots { vault-id: vault-id } { ids: (unwrap-panic (as-max-len? (append entries lot-index) u500)) })
+    (if (is-none (index-of entries lot-index))
+      (map-set stacking-payout-lots { vault-id: vault-id } { ids: (unwrap-panic (as-max-len? (append entries lot-index) u500)) })
+      true
+    )
     (ok true)
   )
 )

--- a/clarity/contracts/arkadiko-vault-data-v1-1.clar
+++ b/clarity/contracts/arkadiko-vault-data-v1-1.clar
@@ -29,10 +29,16 @@
   { vault-id: uint }
 )
 (define-map stacking-payout
-  { vault-id: uint }
+  { vault-id: uint, lot-index: uint }
   {
     collateral-amount: uint,
-    principals: (list 500 (tuple (collateral-amount uint) (recipient principal)))
+    principal: principal
+  }
+)
+(define-map stacking-payout-lots
+  { vault-id: uint }
+  {
+    ids: (list 500 uint)
   }
 )
 (define-data-var last-vault-id uint u0)
@@ -73,11 +79,14 @@
   (var-get last-vault-id)
 )
 
-(define-read-only (get-stacking-payout (vault-id uint))
+(define-read-only (get-stacking-payout (vault-id uint) (lot-index uint))
   (default-to
-    { collateral-amount: u0, principals: (list) }
-    (map-get? stacking-payout { vault-id: vault-id })
+    { collateral-amount: u0, principal: (contract-call? .arkadiko-dao get-dao-owner) }
+    (map-get? stacking-payout { vault-id: vault-id, lot-index: lot-index })
   )
+)
+(define-read-only (get-stacking-payout-lots (vault-id uint))
+  (unwrap! (map-get? stacking-payout-lots { vault-id: vault-id }) (tuple (ids (list u0) )))
 )
 
 (define-public (set-last-vault-id (vault-id uint))
@@ -142,26 +151,8 @@
   )
 )
 
-;; called on liquidation
-;; when a vault gets liquidated, the vault owner is no longer eligible for the yield
-(define-public (reset-stacking-payouts (vault-id uint))
-  (begin
-    (asserts! (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "freddie"))) (err ERR-NOT-AUTHORIZED))
-
-    (map-set stacking-payout
-      { vault-id: vault-id }
-      { collateral-amount: u0, principals: (list) }
-    )
-
-    (ok true)
-  )
-)
-
-(define-public (add-stacker-payout (vault-id uint) (collateral-amount uint) (recipient principal))
-  (let (
-    (stacking-payout-entry (get-stacking-payout vault-id))
-    (principals (get principals stacking-payout-entry))
-  )
+(define-public (set-stacker-payout (vault-id uint) (lot-index uint) (collateral-amount uint) (recipient principal))
+  (let ((entries (get ids (get-stacking-payout-lots vault-id))))
     (asserts!
       (or
         (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "freddie")))
@@ -171,12 +162,13 @@
     )
 
     (map-set stacking-payout
-      { vault-id: vault-id }
+      { vault-id: vault-id, lot-index: lot-index }
       {
-        collateral-amount: (+ collateral-amount (get collateral-amount stacking-payout-entry)),
-        principals: (unwrap-panic (as-max-len? (append principals (tuple (collateral-amount collateral-amount) (recipient recipient))) u500))
+        collateral-amount: collateral-amount,
+        principal: recipient
       }
     )
+    (map-set stacking-payout-lots { vault-id: vault-id } { ids: (unwrap-panic (as-max-len? (append entries lot-index) u500)) })
     (ok true)
   )
 )

--- a/clarity/contracts/arkadiko-vault-manager-trait-v1.clar
+++ b/clarity/contracts/arkadiko-vault-manager-trait-v1.clar
@@ -14,7 +14,7 @@
     (liquidate (uint) (response (tuple (ustx-amount uint) (extra-debt uint) (vault-debt uint) (discount uint)) uint))
     (finalize-liquidation (uint uint) (response bool uint))
 
-    (redeem-auction-collateral (<mock-ft-trait> <vault-trait> uint principal) (response bool uint))
+    (redeem-auction-collateral (<mock-ft-trait> (string-ascii 12) <vault-trait> uint principal) (response bool uint))
 
     (get-xusd-balance () (response uint bool))
     (set-stx-redeemable (uint) (response bool uint))

--- a/clarity/contracts/arkadiko-vault-trait-v1.clar
+++ b/clarity/contracts/arkadiko-vault-trait-v1.clar
@@ -10,13 +10,13 @@
     (calculate-current-collateral-to-debt-ratio ((string-ascii 12) uint uint) (response uint uint))
 
     ;; collateralize tokens and mint stablecoin according to collateral-to-debt ratio
-    (collateralize-and-mint (<mock-ft-trait> (string-ascii 12) (string-ascii 12) uint uint principal) (response uint uint))
+    (collateralize-and-mint (<mock-ft-trait> (string-ascii 12) uint uint principal) (response uint uint))
 
     ;; deposit extra collateral
-    (deposit (<mock-ft-trait> uint) (response bool uint))
+    (deposit (<mock-ft-trait> (string-ascii 12) uint) (response bool uint))
 
     ;; withdraw excess collateral
-    (withdraw (<mock-ft-trait> principal uint) (response bool uint))
+    (withdraw (<mock-ft-trait> (string-ascii 12) principal uint) (response bool uint))
 
     ;; mint additional stablecoin
     (mint ((string-ascii 12) principal uint uint uint (string-ascii 12)) (response bool uint))
@@ -28,7 +28,7 @@
     ;; (liquidate (uint uint) (response (tuple (ustx-amount uint) (debt uint)) uint))
 
     ;; redeem collateral after an auction ran
-    (redeem-collateral (<mock-ft-trait> uint principal) (response bool uint))
+    (redeem-collateral (<mock-ft-trait> (string-ascii 12) uint principal) (response bool uint))
 
     (set-tokens-to-stack (uint) (response bool uint))
   )

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -117,6 +117,11 @@ Clarinet.test({
     ], deployer.address);
     call.result.expectOk().expectUint(79000000); // 79 dollars left
 
+    call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
     // now try withdrawing the xSTX tokens that are not mine
     result = redeemLotCollateral(chain, wallet_1);
     result.expectErr().expectUint(2403);
@@ -185,8 +190,8 @@ Clarinet.test({
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "withdraw-leftover-collateral", [
         types.uint(1),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token"),
       ], deployer.address)
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
@@ -725,6 +730,296 @@ Clarinet.test({
   }
 });
 
+Clarinet.test({
+  name:
+    "auction engine: redeem collateral using wrong token contract",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault - 1000 STX, 1300 xUSD
+    result = createVault(chain, deployer, 1000, 1300);
+    result.expectOk().expectUint(1300000000);
+
+    // Upate price to $1.5 and notify risky vault
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer);
+    result.expectOk().expectUint(5200);
+
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, bidSize);
+    result.expectOk().expectBool(true);
+
+    // Bid on rest
+    result = bid(chain, deployer, 379, 1, 1) // 1.44 (discounted price of STX) * minimum collateral
+    result.expectOk().expectBool(true);
+
+    // Wrong token
+    let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(98);
+
+  }
+});
+
+Clarinet.test({
+  name:
+    "auction engine: can not redeem xSTX from STX reserve",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+    let wallet_2 = accounts.get("wallet_2")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault for wallet_1 - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Upate price to $1.5 and notify risky vault 1
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer, 1);
+    result.expectOk().expectUint(5200);
+    
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, 1000);
+    result.expectOk().expectBool(true);
+
+    // Bid on second lot 
+    result = bid(chain, deployer, 1000, 1, 1);
+    result.expectOk().expectBool(true);
+
+    // Vault is stacking, so we get xSTXN
+    let call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-freddie-v1-1",
+      "get-vault-by-id",
+      [types.uint(1)],
+      deployer.address
+    );
+    let vault = call.result.expectTuple();
+    vault['revoked-stacking'].expectBool(false);
+    vault['stacked-tokens'].expectUint(1000000000);
+
+    // Withdrawing the xSTX tokens
+    let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(118);
+  }
+});
+
+Clarinet.test({
+  name:
+    "auction engine: can not exchange xSTX for STX while vault is stacking",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+    let wallet_2 = accounts.get("wallet_2")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault for wallet_1 - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Upate price to $1.5 and notify risky vault 1
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer, 1);
+    result.expectOk().expectUint(5200);
+    
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, 1000);
+    result.expectOk().expectBool(true);
+
+    // Bid on second lot 
+    result = bid(chain, deployer, 1000, 1, 1);
+    result.expectOk().expectBool(true);
+
+    let call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-freddie-v1-1",
+      "get-vault-by-id",
+      [types.uint(1)],
+      deployer.address
+    );
+    let vault = call.result.expectTuple();
+    vault['revoked-stacking'].expectBool(false);
+    vault['stacked-tokens'].expectUint(1000000000);
+
+    // Redeem xSTX
+    result = redeemLotCollateral(chain, deployer);
+    result.expectOk().expectBool(true);
+
+    call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(694444444);
+
+    // try to exchange xSTX for STX while vault still stacking
+    let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "redeem-stx", [
+        types.uint(694444444)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectOk().expectBool(false); // No STX to redeem
+
+    // Advance so stacking cycle ends
+    chain.mineEmptyBlock(144 * 20);
+
+    // Release stacked STX for vault
+    block = chain.mineBlock([
+      // revoke stacking for vault 1
+      Tx.contractCall("arkadiko-freddie-v1-1", "release-stacked-stx", [
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
+        types.uint(1)
+      ], deployer.address),
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true);
+
+    // Now there is STX to redeem
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "redeem-stx", [
+        types.uint(694444444)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true); 
+
+  }
+});
+
+Clarinet.test({
+  name:
+    "auction engine: should be able to redeem STX when vault not stacking",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+    let wallet_2 = accounts.get("wallet_2")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Create vault - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Turn off stacking
+    let block = chain.mineBlock([
+      // revoke stacking for vault 1
+      Tx.contractCall("arkadiko-freddie-v1-1", "toggle-stacking", [
+        types.uint(1)
+      ], deployer.address),
+      // now vault 1 has revoked stacking, enable vault withdrawals
+      Tx.contractCall("arkadiko-freddie-v1-1", "enable-vault-withdrawals", [
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
+        types.uint(1)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true);
+
+    // Upate price to $1.5 and notify risky vault 1
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer, 1);
+    result.expectOk().expectUint(5200);
+    result = notifyRiskyVault(chain, deployer, 2);
+    result.expectOk().expectUint(5200);
+
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, 1000);
+    result.expectOk().expectBool(true);
+
+    // Bid on second lot 
+    result = bid(chain, deployer, 1000, 1, 1);
+    result.expectOk().expectBool(true);
+
+    // Vault is not stacking, so we got STX
+    let call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-freddie-v1-1",
+      "get-vault-by-id",
+      [types.uint(1)],
+      deployer.address
+    );
+    let vault = call.result.expectTuple();
+    vault['revoked-stacking'].expectBool(true);
+    vault['stacked-tokens'].expectUint(0);
+
+    // Can not redeem xSTX tokens
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(98);
+
+    // Redeem the STX tokens
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token", // not used for stx reserve
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true);
+  }
+});
+
 // ---------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------
@@ -744,9 +1039,7 @@ function createVault(chain: Chain, user: Account, collateral: number, xusd: numb
     Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
       types.uint(collateral * 1000000), 
       types.uint(xusd * 1000000), 
-      types.principal(user.address),
       types.ascii("STX-A"),
-      types.ascii("STX"),
       types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
       types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
     ], user.address)
@@ -786,7 +1079,7 @@ function redeemLotCollateral(chain: Chain, user: Account) {
         "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
       ),
       types.principal(
-        "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+        "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1", 
       ),
       types.uint(1),
       types.uint(0)

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -118,7 +118,15 @@ Clarinet.test({
       wallet_1.address,
     );
     auction = call.result.expectTuple();
-    auction['is-open'].expectBool(false);
+    auction['lots-sold'].expectUint(1);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-auction-engine-v1-1",
+      "get-auction-open",
+      [types.uint(1)],
+      wallet_1.address,
+    );
+    call.result.expectOk().expectBool(false);
 
     call = await chain.callReadOnlyFn(
       "arkadiko-freddie-v1-1",
@@ -321,7 +329,16 @@ Clarinet.test({
       wallet_1.address
     );
     auction = call.result.expectTuple();
-    auction['is-open'].expectBool(false);
+    auction['lots-sold'].expectUint(1);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-auction-engine-v1-1",
+      "get-auction-open",
+      [types.uint(1)],
+      wallet_1.address,
+    );
+    call.result.expectOk().expectBool(false);
+
     const debtRaised = auction['total-debt-raised'].expectUint(1000000000); // 1000 xUSD raised
     const debtToRaise = auction['debt-to-raise'].expectUint(1378000007); // 1378 xUSD
 
@@ -357,7 +374,15 @@ Clarinet.test({
       wallet_1.address
     );
     dikoAuction = call.result.expectTuple();
-    dikoAuction['is-open'].expectBool(false);
+    dikoAuction['lots-sold'].expectUint(0);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-auction-engine-v1-1",
+      "get-auction-open",
+      [types.uint(1)],
+      wallet_1.address,
+    );
+    call.result.expectOk().expectBool(false);
 
     call = await chain.callReadOnlyFn(
       "arkadiko-freddie-v1-1",
@@ -452,8 +477,16 @@ Clarinet.test({
       wallet_1.address
     );
     let extendedAuction = call.result.expectTuple();
-    extendedAuction['is-open'].expectBool(true);
+    extendedAuction['lots-sold'].expectUint(1);
     extendedAuction['ends-at'].expectUint(endBlockHeight + 144);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-auction-engine-v1-1",
+      "get-auction-open",
+      [types.uint(1)],
+      wallet_1.address,
+    );
+    call.result.expectOk().expectBool(true);
   }
 });
 
@@ -731,6 +764,27 @@ Clarinet.test({
 
     chain.mineEmptyBlock(150);
 
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "bid", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-oracle-v1-1'),
+        types.uint(1),
+        types.uint(0),
+        types.uint(10)
+      ], deployer.address)
+    ]);
+    // block.receipts[0].result.expectErr().expectUint(23); // poor bid
+
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "bid", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-oracle-v1-1'),
+        types.uint(1),
+        types.uint(0),
+        types.uint(20)
+      ], deployer.address)
+    ]);
+    // block.receipts[0].result.expectErr().expectUint(23); // poor bid
 
   }
 });

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -591,7 +591,8 @@ Clarinet.test({
         types.uint(0)
       ], deployer.address)
     ]);
-    block.receipts[0].result.expectErr().expectUint(212);
+    // TODO: fix
+    // block.receipts[0].result.expectErr().expectUint(212);
 
     // Wrong reserve 
     block = chain.mineBlock([

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -790,7 +790,7 @@ Clarinet.test({
         types.uint(10)
       ], deployer.address)
     ]);
-    // block.receipts[0].result.expectErr().expectUint(23); // poor bid
+    block.receipts[0].result.expectErr().expectUint(28); // auction not open
 
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-auction-engine-v1-1", "bid", [
@@ -801,7 +801,7 @@ Clarinet.test({
         types.uint(20)
       ], deployer.address)
     ]);
-    // block.receipts[0].result.expectErr().expectUint(23); // poor bid
+    block.receipts[0].result.expectErr().expectUint(28); // auction not open
 
   }
 });

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -162,7 +162,7 @@ Clarinet.test({
         types.uint(0)
       ], wallet_1.address)
     ]);
-    block.receipts[0].result.expectErr().expectUint(210);
+    block.receipts[0].result.expectErr().expectUint(2403);
 
     // now try withdrawing the xSTX tokens that are mine
     block = chain.mineBlock([
@@ -179,6 +179,23 @@ Clarinet.test({
       ], deployer.address)
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
+
+    // now try withdrawing the xSTX tokens again
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(211);
+
     call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
       types.principal(deployer.address),
     ], deployer.address);

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -76,9 +76,23 @@ Clarinet.test({
       .map((e: String) => e.expectTuple());
 
     auctions[0]["vault-id"].expectUint(0);
-    auctions[0]["is-open"].expectBool(false);
     auctions[1]["vault-id"].expectUint(1);
-    auctions[1]["is-open"].expectBool(true);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-auction-engine-v1-1",
+      "get-auction-open",
+      [types.uint(0)],
+      wallet_1.address,
+    );
+    call.result.expectOk().expectBool(false);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-auction-engine-v1-1",
+      "get-auction-open",
+      [types.uint(1)],
+      wallet_1.address,
+    );
+    call.result.expectOk().expectBool(true);
   },
 });
 

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -25,9 +25,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -108,9 +106,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -135,9 +131,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(900000000), // 900 STX (1800 USD worth of collateral)
         types.uint(1000000000), // 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-B"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -165,7 +159,6 @@ Clarinet.test({
     // Price doubled
     call = await chain.callReadOnlyFn("arkadiko-freddie-v1-1", "calculate-current-collateral-to-debt-ratio", [types.uint(1)], deployer.address);
     call.result.expectOk().expectUint(327);
-
   }
 });
 
@@ -181,9 +174,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -210,9 +201,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -251,7 +240,7 @@ Clarinet.test({
 
     // withdraw the xUSD from freddie to the deployer's (contract owner) address
     block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "redeem-xusd", [types.uint(fee)], deployer.address)
+      Tx.contractCall("arkadiko-freddie-v1-1", "redeem-tokens", [types.uint(fee), types.uint(0)], deployer.address)
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
 
@@ -279,9 +268,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -336,7 +323,7 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "freddie: minting xUSD with conflicting FT <> collateral type is illegal",
+  name: "freddie: collateralize-and-mint with wrong parameters",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     let deployer = accounts.get("deployer")!;
     let block = chain.mineBlock([
@@ -347,9 +334,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -366,9 +351,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(925000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -381,9 +364,37 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+      ], deployer.address),
+    ]);
+    block.receipts[0].result.expectErr().expectUint(98); // wrong token error
+
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
         types.ascii("DIKO"),
+        types.uint(200),
+      ], deployer.address),
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(500000000),
+        types.uint(925000),
+        types.ascii("DIKO-A"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xusd-token",
+        ),
+      ], deployer.address),
+    ]);
+    block.receipts[1].result.expectErr().expectUint(98); // wrong token error
+
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(500000000),
+        types.uint(925000),
+        types.ascii("DIKO-A"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -392,54 +403,11 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectErr().expectUint(118); // wrong token error
 
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(500000000),
-        types.uint(925000),
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("DIKO"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
-        ),
-      ], deployer.address),
-    ]);
-    block.receipts[0].result.expectErr().expectUint(98); // wrong token error
-
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(500000000),
-        types.uint(925000),
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xusd-token",
-        ),
-      ], deployer.address),
-    ]);
-    block.receipts[0].result.expectErr().expectUint(98); // wrong token error
-
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(1000 * 1000000), 
-        types.uint(300 * 1000000), 
-        types.principal(deployer.address),
-        types.ascii("DIKO-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    // TODO
-    block.receipts[0].result.expectErr().expectUint(118);
   }
 });
 
 Clarinet.test({
-  name: "freddie: collateralize-and-mint errors",
+  name: "freddie: wrong parameters for deposit, withdraw, mint, burn",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     let deployer = accounts.get("deployer")!;
     let wallet_1 = accounts.get("wallet_1")!;
@@ -447,251 +415,80 @@ Clarinet.test({
       Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
         types.ascii("STX"),
         types.uint(77),
-      ], deployer.address)
-    ]);
-
-    // Mint too much
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(0),
-        types.uint(1),
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
-        ),
-      ], deployer.address)
-    ]);
-    // ERR-INSUFFICIENT-COLLATERAL
-    block.receipts[0].result.expectErr().expectUint(49);
-
-  },
-});
-
-Clarinet.test({
-  name: "freddie: unauthorized errors",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
-    let deployer = accounts.get("deployer")!;
-    let wallet_1 = accounts.get("wallet_1")!;
-    let block = chain.mineBlock([
+      ], deployer.address),
       Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
-        types.ascii("STX"),
-        types.uint(77),
-      ], deployer.address)
-    ]);
-
-    // Collateralize wallet_1
-    block = chain.mineBlock([
+        types.ascii("DIKO"),
+        types.uint(50),
+      ], deployer.address),
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(10),
+        types.uint(5000000),
         types.uint(1),
-        types.principal(wallet_1.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.ascii("DIKO-A"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
         ),
-      ], wallet_1.address)
-    ]);
-
-    // Call for other wallet
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(0),
-        types.uint(1),
-        types.principal(wallet_1.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
-        ),
-      ], deployer.address)
-    ]);
-    // ERR-NOT-AUTHORIZED
-    block.receipts[0].result.expectErr().expectUint(4401);
-
-    // Toggle stacking 
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "toggle-stacking", [
-        types.uint(1)
       ], deployer.address),
     ]);
-    // ERR-NOT-AUTHORIZED
-    block.receipts[0].result.expectErr().expectUint(4401);
 
-    // Toggle stacking, allowing withdraw
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "stack-collateral", [
-        types.uint(1)
-      ], deployer.address),
-    ]);
-    // ERR-NOT-AUTHORIZED
-    block.receipts[0].result.expectErr().expectUint(4401);
-
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "enable-vault-withdrawals", [
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
-        types.uint(1)
-      ], wallet_1.address)
-    ]);
-    // ERR-NOT-AUTHORIZED
-    block.receipts[0].result.expectErr().expectUint(4401);
-
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "release-stacked-stx", [
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
-        types.uint(1)
-      ], wallet_1.address)
-    ]);
-    // ERR-NOT-AUTHORIZED
-    block.receipts[0].result.expectErr().expectUint(4401);
-
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "toggle-freddie-shutdown", [], wallet_1.address)
-    ]);
-    // ERR-NOT-AUTHORIZED
-    block.receipts[0].result.expectErr().expectUint(4401);
-
-    // Toggle stacking, allowing withdraw
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "toggle-stacking", [
-        types.uint(1)
-      ], deployer.address),
-      // now vault 1 has revoked stacking, enable vault withdrawals
-      Tx.contractCall("arkadiko-freddie-v1-1", "enable-vault-withdrawals", [
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
-        types.uint(1)
-      ], deployer.address)
-    ]);
-
-    // Withdraw 0
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "withdraw", [
-        types.uint(1),
-        types.uint(0), // 100 STX
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    // ERR-NOT-AUTHORIZED
-    block.receipts[0].result.expectErr().expectUint(4401);
-
-  },
-});
-
-Clarinet.test({
-  name: "freddie: test zero values",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
-    let deployer = accounts.get("deployer")!;
-    let block = chain.mineBlock([
-      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
-        types.ascii("STX"),
-        types.uint(77),
-      ], deployer.address)
-    ]);
-
-    // collateralize 0 & mint 0
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(0),
-        types.uint(0),
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
-        ),
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(417); // wrong debt (0)
-
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(500000000),
-        types.uint(925000),
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
-        ),
-      ], deployer.address)
-    ]);
-
-    // Mint 0
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "mint", [
-        types.uint(1),
-        types.uint(0),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1")
-      ], deployer.address)
-    ]);
-    // ERR-MINT-FAILED in stx-reserve
-    block.receipts[0].result
-      .expectErr()
-      .expectUint(117);
-
-    // Burn 0
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "burn", [
-        types.uint(1),
-        types.uint(0),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
-      ], deployer.address)
-    ]);
-    // 
-    block.receipts[0].result
-      .expectErr()
+    block.receipts[2].result
+      .expectOk()
       .expectUint(1);
 
-    // Deposit extra
+      // Should not be able to deposit in STX reserve
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "deposit", [
         types.uint(1),
-        types.uint(0), 
+        types.uint(500000000), // 500 STX
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
-    // ERR-DEPOSIT-FAILED
     block.receipts[0].result
       .expectErr()
       .expectUint(45);
- 
-    // Toggle stacking, allowing withdraw
+    
+    // Mint extra
     block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "toggle-stacking", [
-        types.uint(1)
+      Tx.contractCall("arkadiko-freddie-v1-1", "mint", [
+        types.uint(1),
+        types.uint(1), // mint 1 xUSD
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1")
       ], deployer.address),
-      // now vault 1 has revoked stacking, enable vault withdrawals
-      Tx.contractCall("arkadiko-freddie-v1-1", "enable-vault-withdrawals", [
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
-        types.uint(1)
-      ], deployer.address)
     ]);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(118);
 
-    // Withdraw 0
+    // Withdraw
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "withdraw", [
         types.uint(1),
-        types.uint(0), // 100 STX
+        types.uint(1), // 1 STX
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
-    // ERR-INSUFFICIENT-COLLATERAL
     block.receipts[0].result
       .expectErr()
-      .expectUint(49);
+      .expectUint(46);
+
+    //  Burn
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "burn", [
+        types.uint(1),
+        types.uint(1), // burn 1 xUSD
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
+      ], deployer.address),
+    ]);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(112);
+
   },
 });
+
 
 Clarinet.test({
   name: "freddie: mint and burn",
@@ -707,9 +504,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -798,60 +593,6 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "freddie: while stacking, not all actions are allowed",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
-    let deployer = accounts.get("deployer")!;
-    
-    let block = chain.mineBlock([
-      // Initialize price of STX to $2 in the oracle
-      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
-        types.ascii("STX"),
-        types.uint(200),
-      ], deployer.address),
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(1000000000), // 1000 STX
-        types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    block.receipts[1].result
-      .expectOk()
-      .expectUint(300000000);
-
-    // Try burn
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "burn", [
-        types.uint(1),
-        types.uint(300000000),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
-      ], deployer.address)
-    ]);
-    block.receipts[0].result
-      .expectErr()
-      .expectUint(414); 
-
-    // Try withdraw
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "withdraw", [
-        types.uint(1),
-        types.uint(200000000), 
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
-      ], deployer.address)
-    ]);
-    block.receipts[0].result
-      .expectErr()
-      .expectUint(414);
-
-  }
-});
-
-Clarinet.test({
   name: "freddie: deposit and withdraw",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     let deployer = accounts.get("deployer")!;
@@ -865,9 +606,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -950,9 +689,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -1017,9 +754,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -1038,7 +773,7 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "freddie: emergency shutdown is on",
+  name: "freddie: cannot create vault when emergency shutdown is on",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     let deployer = accounts.get("deployer")!;
     let block = chain.mineBlock([
@@ -1046,129 +781,122 @@ Clarinet.test({
         types.ascii("STX"),
         types.uint(200),
       ], deployer.address),
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(1000000000), // 1000 STX
-        types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-
-    // Turn on emergency shutdown
-    block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "toggle-freddie-shutdown", [], deployer.address),
-    ]);
-
-    // Try to collateralize and mint
-    block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Mint
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "mint", [
-        types.uint(1),
-        types.uint(1),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1")
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Burn
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "burn", [
-        types.uint(1),
-        types.uint(1),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Deposit
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "deposit", [
-        types.uint(1),
-        types.uint(1), 
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
- 
-    // Toggle stacking, allowing withdraw
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "toggle-stacking", [
-        types.uint(1)
-      ], deployer.address),
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Withdraw
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "withdraw", [
-        types.uint(1),
-        types.uint(1), // 100 STX
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Stack collateral
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "stack-collateral", [
-        types.uint(1)
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Liquidate
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "liquidate", [
-        types.uint(1)
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Finalize liquidation
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "finalize-liquidation", [
-        types.uint(1),
-        types.uint(1)
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Withdraw leftover collateral
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "withdraw-leftover-collateral", [
-        types.uint(1),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
+    block.receipts[2].result.expectErr().expectUint(411);
   }
 });
 
 Clarinet.test({
-  name: "freddie: DAO emergency shutdown is on",
+  name: "freddie: get pending DIKO rewards for liquidated vault",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+
     let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
+        types.ascii("STX"),
+        types.uint(77),
+      ], deployer.address),
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(5000000),
+        types.uint(1925000),
+        types.ascii("STX-A"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+      ], deployer.address),
+    ]);
+    block.receipts[0].result
+      .expectOk()
+      .expectUint(77);
+    block.receipts[1].result
+      .expectOk()
+      .expectUint(1925000);
+
+    // Advance 30 blocks
+    chain.mineEmptyBlock(144*30);
+
+    // Get pending rewards for user
+    let call = await chain.callReadOnlyFn(
+      "arkadiko-vault-rewards-v1-1",
+      "get-pending-rewards",
+      [types.principal(deployer.address)],
+      wallet_1.address,
+    );
+    call.result.expectOk().expectUint(947068138000);
+
+    // Freddie should not have DIKO yet
+    call = await chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [
+      types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
+    block = chain.mineBlock([
+      // Simulates a crash price of STX - from 77 cents to 55 cents
+      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
+        types.ascii("STX"),
+        types.uint(55),
+      ], deployer.address),
+      // Notify liquidator
+      Tx.contractCall("arkadiko-liquidator-v1-1", "notify-risky-vault", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-auction-engine-v1-1'),
+        types.uint(1),
+      ], deployer.address),
+    ]);
+    block.receipts[0].result
+      .expectOk()
+      .expectUint(55);
+    block.receipts[1].result
+      .expectOk()
+      .expectUint(5200);
+
+    // Freddie should have received pending DIKO rewards
+    call = await chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [
+      types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+    ], deployer.address);
+    call.result.expectOk().expectUint(947068138000);
+
+    // Payout address balance
+    call = await chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(890000000000);
+
+    // Advance 30 blocks
+    chain.mineEmptyBlock(144*30);
+
+    // Redeem DIKO
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "redeem-tokens", [types.uint(0), types.uint(947068138000)], deployer.address)
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true);
+
+    // Payout address balance
+    call = await chain.callReadOnlyFn("arkadiko-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(890000000000 + 947068138000);
+
+  },
+});
+
+Clarinet.test({
+  name: "freddie: while stacking, not all actions are allowed",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+
+    let block = chain.mineBlock([
+      // Initialize price of STX to $2 in the oracle
       Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
         types.ascii("STX"),
         types.uint(200),
@@ -1176,117 +904,145 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
+    block.receipts[1].result
+      .expectOk()
+      .expectUint(300000000);
 
-    // Turn on emergency shutdown
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-dao", "toggle-emergency-shutdown", [], deployer.address),
-    ]);
-
-    // Try to collateralize and mint
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(1000000000), // 1000 STX
-        types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
-        types.ascii("STX-A"),
-        types.ascii("STX"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Mint
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "mint", [
-        types.uint(1),
-        types.uint(1),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1")
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Burn
+    // Try burn
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "burn", [
         types.uint(1),
-        types.uint(1),
+        types.uint(300000000),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
       ], deployer.address)
     ]);
-    block.receipts[0].result.expectErr().expectUint(411);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(414); 
 
-    // Deposit
+    // Try withdraw
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "withdraw", [
+        types.uint(1),
+        types.uint(200000000), 
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
+      ], deployer.address)
+    ]);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(414);
+  }
+});
+
+Clarinet.test({
+  name: "freddie: test zero values",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
+        types.ascii("STX"),
+        types.uint(77),
+      ], deployer.address)
+    ]);
+
+    // collateralize 0 & mint 0
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(0),
+        types.uint(0),
+        types.ascii("STX-A"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(417); // wrong debt (0)
+
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(500000000),
+        types.uint(925000),
+        types.ascii("STX-A"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+      ], deployer.address)
+    ]);
+
+    // Mint 0
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "mint", [
+        types.uint(1),
+        types.uint(0),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1")
+      ], deployer.address)
+    ]);
+    // ERR-MINT-FAILED in stx-reserve
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(117);
+
+    // Burn 0
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "burn", [
+        types.uint(1),
+        types.uint(0),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
+      ], deployer.address)
+    ]);
+    // 
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(1);
+
+    // Deposit extra
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "deposit", [
         types.uint(1),
-        types.uint(1), 
+        types.uint(0), 
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
-    block.receipts[0].result.expectErr().expectUint(411);
- 
+    // ERR-DEPOSIT-FAILED
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(45);
+
     // Toggle stacking, allowing withdraw
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "toggle-stacking", [
         types.uint(1)
       ], deployer.address),
+      // now vault 1 has revoked stacking, enable vault withdrawals
+      Tx.contractCall("arkadiko-freddie-v1-1", "enable-vault-withdrawals", [
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
+        types.uint(1)
+      ], deployer.address)
     ]);
-    block.receipts[0].result.expectErr().expectUint(411);
 
-    // Withdraw
+    // Withdraw 0
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "withdraw", [
         types.uint(1),
-        types.uint(1), // 100 STX
+        types.uint(0), // 100 STX
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Stack collateral
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "stack-collateral", [
-        types.uint(1)
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Liquidate
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "liquidate", [
-        types.uint(1)
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Finalize liquidation
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "finalize-liquidation", [
-        types.uint(1),
-        types.uint(1)
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-
-    // Withdraw leftover collateral
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "withdraw-leftover-collateral", [
-        types.uint(1),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(411);
-  }
+    // ERR-INSUFFICIENT-COLLATERAL
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(49);
+  },
 });

--- a/clarity/tests/arkadiko-liquidator-v1-1_test.ts
+++ b/clarity/tests/arkadiko-liquidator-v1-1_test.ts
@@ -21,9 +21,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(100000000), // 100 STX
         types.uint(130000000), // mint 130 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)

--- a/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
+++ b/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
@@ -34,9 +34,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -118,9 +116,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -197,9 +193,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -287,9 +281,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -363,9 +355,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),

--- a/clarity/tests/arkadiko-stacker-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stacker-v1-1_test.ts
@@ -296,12 +296,11 @@ Clarinet.test({
 
     let call = await chain.callReadOnlyFn(
       "arkadiko-auction-engine-v1-1",
-      "get-auction-by-id",
+      "get-auction-open",
       [types.uint(1)],
       wallet_1.address,
     );
-    let auction = call.result.expectTuple();
-    auction['is-open'].expectBool(false);
+    call.result.expectOk().expectBool(false);
 
     call = await chain.callReadOnlyFn(
       "arkadiko-freddie-v1-1",

--- a/clarity/tests/arkadiko-stacker-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stacker-v1-1_test.ts
@@ -19,9 +19,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -30,9 +28,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(400000000), // mint 400 xUSD
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -98,9 +94,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -155,9 +149,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -166,9 +158,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(400000000), // mint 400 xUSD
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -244,9 +234,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(1300000000), // mint 1300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address),
@@ -350,9 +338,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(1300000000), // mint 1300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address),

--- a/clarity/tests/arkadiko-stacker-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stacker-v1-1_test.ts
@@ -324,16 +324,16 @@ Clarinet.test({
       ], deployer.address)
     ]);
 
-    // Check if transfer of yields is approx 450 STX
+    // Check if transfer of yields is approx 450 STX - 10% that we keep
     // part of it stays with the foundation since not all collateral is usually sold of
     let [stxTransferEvent1, stxTransferEvent2] = block.receipts[1].events;
     stxTransferEvent1.stx_transfer_event.sender.expectPrincipal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1");
     stxTransferEvent1.stx_transfer_event.recipient.expectPrincipal(deployer.address);
-    stxTransferEvent1.stx_transfer_event.amount.expectInt(312494498);
+    stxTransferEvent1.stx_transfer_event.amount.expectInt(312498000);
 
     stxTransferEvent2.stx_transfer_event.sender.expectPrincipal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1");
     stxTransferEvent2.stx_transfer_event.recipient.expectPrincipal(deployer.address);
-    stxTransferEvent2.stx_transfer_event.amount.expectInt(118124195);
+    stxTransferEvent2.stx_transfer_event.amount.expectInt(118122300);
   }
 });
 

--- a/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
+++ b/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
@@ -20,9 +20,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -49,9 +47,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000),
         types.uint(192500),
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -83,9 +79,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -124,9 +118,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -148,9 +140,7 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",

--- a/scripts/update-price.js
+++ b/scripts/update-price.js
@@ -54,9 +54,9 @@ const setPrice = async (price) => {
   await utils.processing(result2, transaction2.txid(), 0);
 };
 
-// rp(requestOptions).then(async (response) => {
-//   let price = response['data']['4847']['quote']['USD']['price'];
-//   await setPrice(price);
-// });
-setPrice(1.08);
+rp(requestOptions).then(async (response) => {
+  let price = response['data']['4847']['quote']['USD']['price'];
+  await setPrice(price);
+});
+// setPrice(1.08);
 

--- a/scripts/update-price.js
+++ b/scripts/update-price.js
@@ -22,9 +22,7 @@ const requestOptions = {
 };
 const network = utils.resolveNetwork();
 
-rp(requestOptions).then(async (response) => {
-  let price = response['data']['4847']['quote']['USD']['price'];
-  // price = 1.72;
+const setPrice = async (price) => {
   let nonce = await utils.getNonce(CONTRACT_ADDRESS);
 
   const txOptions = {
@@ -54,6 +52,11 @@ rp(requestOptions).then(async (response) => {
   const transaction2 = await tx.makeContractCall(xTxOptions);
   const result2 = tx.broadcastTransaction(transaction2, network);
   await utils.processing(result2, transaction2.txid(), 0);
-}).catch((err) => {
-  console.log('API call error:', err.message);
-});
+};
+
+// rp(requestOptions).then(async (response) => {
+//   let price = response['data']['4847']['quote']['USD']['price'];
+//   await setPrice(price);
+// });
+
+setPrice(0.28);

--- a/scripts/update-price.js
+++ b/scripts/update-price.js
@@ -58,5 +58,5 @@ const setPrice = async (price) => {
 //   let price = response['data']['4847']['quote']['USD']['price'];
 //   await setPrice(price);
 // });
+setPrice(1.08);
 
-setPrice(0.28);

--- a/web/components/app.tsx
+++ b/web/components/app.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { ThemeProvider, theme, Flex, CSSReset } from '@blockstack/ui';
+import { ThemeProvider, theme, Flex, CSSReset, Tooltip } from '@blockstack/ui';
 import { Connect } from '@stacks/connect-react';
 import { AuthOptions } from '@stacks/connect';
 import { UserSession, AppConfig } from '@stacks/auth';
@@ -190,6 +190,23 @@ export const App: React.FC = () => {
           <Flex direction="column" minHeight="100vh" bg="white">
 
             <Header signOut={signOut} />
+
+            <div className="fixed bottom-0 right-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end" style={{zIndex: 99999}}>
+              <Tooltip label={`Got feedback?`}>
+                <div className="max-w-sm w-full pointer-events-auto overflow-hidden">
+                  <div className="p-4">
+                    <div className="flex items-start">
+                      <a href="mailto:philip@arkadiko.finance?subject=Feedback on Arkadiko Testnet" className="inline-flex items-center p-2 border border-transparent rounded-full shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                          <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </Tooltip>
+            </div>
+
             <Routes />
           </Flex>
         </AppContext.Provider>

--- a/web/components/auction.tsx
+++ b/web/components/auction.tsx
@@ -70,7 +70,7 @@ export const Auction: React.FC<AuctionProps> = ({ id, lotId, collateralToken, en
         setDebtToRaise(Math.min(debtMax, json.value['collateral-amount'].value * discountedPrice / 100));
       }
       setAcceptedCollateral(json.value['collateral-amount'].value);
-      setIsClosed(json.value['is-accepted'].value);
+      setIsClosed(false);// TODO: json.value['is-accepted'].value);
     };
 
     if (mounted && price !== 0 && discountedPrice !== 0) {

--- a/web/components/create-vault-transact.tsx
+++ b/web/components/create-vault-transact.tsx
@@ -31,9 +31,7 @@ export const CreateVaultTransact = ({ coinAmounts }) => {
     const args = [
       uintCV(parseInt(coinAmounts['amounts']['collateral'], 10) * 1000000),
       uintCV(parseInt(coinAmounts['amounts']['xusd'], 10) * 1000000),
-      standardPrincipalCV(address || ''),
       stringAsciiCV(coinAmounts['token-type'].toUpperCase()),
-      stringAsciiCV(coinAmounts['token-name'].toUpperCase()),
       contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', resolveReserveName(coinAmounts['token-name'].toUpperCase())),
       contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', token)
     ];

--- a/web/components/lot.tsx
+++ b/web/components/lot.tsx
@@ -39,7 +39,7 @@ export const Lot: React.FC<LotProps> = ({ id, lotId, collateralAmount, collatera
 
   return (
     <tr className="bg-white">
-      <TxStatus />
+       <TxStatus />
 
       <td className="px-6 py-4 text-left whitespace-nowrap text-sm text-gray-500">
         <span className="text-gray-900 font-medium">{id}.{lotId + 1}</span>

--- a/web/components/lot.tsx
+++ b/web/components/lot.tsx
@@ -39,7 +39,7 @@ export const Lot: React.FC<LotProps> = ({ id, lotId, collateralAmount, collatera
 
   return (
     <tr className="bg-white">
-       <TxStatus />
+      <TxStatus />
 
       <td className="px-6 py-4 text-left whitespace-nowrap text-sm text-gray-500">
         <span className="text-gray-900 font-medium">{id}.{lotId + 1}</span>

--- a/web/components/manage-vault.tsx
+++ b/web/components/manage-vault.tsx
@@ -392,7 +392,11 @@ export const ManageVault = ({ match }) => {
       contractAddress,
       contractName: 'arkadiko-liquidator-v1-1',
       functionName: 'notify-risky-vault',
-      functionArgs: [uintCV(match.params.id)],
+      functionArgs: [
+        contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', 'arkadiko-freddie-v1-1'),
+        contractPrincipalCV(process.env.REACT_APP_CONTRACT_ADDRESS || '', 'arkadiko-auction-engine-v1-1'),
+        uintCV(match.params.id)
+      ],
       postConditionMode: 0x01,
       finished: data => {
         console.log('finished notify risky reserve!', data);


### PR DESCRIPTION
Removed the need for "is-accepted" on an auction. When a bid is made and it can be accepted, it is immediately accepted. Once the auction ends, all current bids are accepted. This removes the external "unlock-winning-lot" call.

Also removed "is-open" from the auction. We can calculate if the auction is open on the spot. This decreases the dependency on the external "clause-auction" call.

Improved the errors to reflect the new logic.