### PR TITLE
[3] Reserve improvements and tests

### DIFF
--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -276,7 +276,7 @@
   (let (
     (sender tx-sender)
     (collateral-token (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name collateral-type))))
-    (ratio (unwrap-panic (contract-call? reserve calculate-current-collateral-to-debt-ratio collateral-token debt collateral-amount)))
+    (ratio (unwrap! (contract-call? reserve calculate-current-collateral-to-debt-ratio collateral-token debt collateral-amount) (err ERR-WRONG-DEBT)))
   )
     (asserts!
       (and

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -612,7 +612,10 @@
 )
 
 (define-public (redeem-auction-collateral (ft <mock-ft-trait>) (reserve <vault-trait>) (collateral-amount uint) (sender principal))
-  (contract-call? reserve redeem-collateral ft collateral-amount sender)
+  (begin
+    (asserts! (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "auction-engine"))) (err ERR-NOT-AUTHORIZED))
+    (contract-call? reserve redeem-collateral ft collateral-amount sender)
+  )
 )
 
 (define-public (withdraw-leftover-collateral (vault-id uint) (reserve <vault-trait>) (ft <mock-ft-trait>))

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -611,10 +611,10 @@
   )
 )
 
-(define-public (redeem-auction-collateral (ft <mock-ft-trait>) (reserve <vault-trait>) (collateral-amount uint) (sender principal))
+(define-public (redeem-auction-collateral (ft <mock-ft-trait>) (token-string (string-ascii 12)) (reserve <vault-trait>) (collateral-amount uint) (sender principal))
   (begin
     (asserts! (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "auction-engine"))) (err ERR-NOT-AUTHORIZED))
-    (contract-call? reserve redeem-collateral ft collateral-amount sender)
+    (contract-call? reserve redeem-collateral ft token-string collateral-amount sender)
   )
 )
 

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -255,13 +255,15 @@
 (define-public (collateralize-and-mint
     (collateral-amount uint)
     (debt uint)
-    (sender principal)
     (collateral-type (string-ascii 12))
     (collateral-token (string-ascii 12))
     (reserve <vault-trait>)
     (ft <mock-ft-trait>)
   )
-  (let ((ratio (unwrap-panic (contract-call? reserve calculate-current-collateral-to-debt-ratio collateral-token debt collateral-amount))))
+  (let (
+    (sender tx-sender)
+    (ratio (unwrap-panic (contract-call? reserve calculate-current-collateral-to-debt-ratio collateral-token debt collateral-amount)))
+  )
     (asserts!
       (and
         (is-eq (unwrap-panic (contract-call? .arkadiko-dao get-emergency-shutdown-activated)) false)
@@ -269,7 +271,6 @@
       )
       (err ERR-EMERGENCY-SHUTDOWN-ACTIVATED)
     )
-    (asserts! (is-eq tx-sender sender) (err ERR-NOT-AUTHORIZED))
     (asserts! (>= ratio (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-liquidation-ratio collateral-type))) (err ERR-INSUFFICIENT-COLLATERAL))
     (asserts!
       (<

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -282,7 +282,7 @@
       (err ERR-MAXIMUM-DEBT-REACHED)
     )
 
-    (try! (contract-call? reserve collateralize-and-mint ft collateral-token collateral-type collateral-amount debt sender))
+    (try! (contract-call? reserve collateralize-and-mint ft collateral-token collateral-amount debt sender))
     (try! (as-contract (contract-call? .arkadiko-dao mint-token .xusd-token debt sender)))
     (let (
       (vault-id (+ (contract-call? .arkadiko-vault-data-v1-1 get-last-vault-id) u1))

--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -252,16 +252,18 @@
   )
 )
 
+
+
 (define-public (collateralize-and-mint
     (collateral-amount uint)
     (debt uint)
     (collateral-type (string-ascii 12))
-    (collateral-token (string-ascii 12))
     (reserve <vault-trait>)
     (ft <mock-ft-trait>)
   )
   (let (
     (sender tx-sender)
+    (collateral-token (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name collateral-type))))
     (ratio (unwrap-panic (contract-call? reserve calculate-current-collateral-to-debt-ratio collateral-token debt collateral-amount)))
   )
     (asserts!

--- a/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
@@ -34,9 +34,12 @@
 
 ;; (match (print (ft-transfer? token ucollateral-amount sender (as-contract tx-sender)))
 (define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (type (string-ascii 12)) (ucollateral-amount uint) (debt uint) (sender principal))
-  (let ((token-symbol (unwrap-panic (contract-call? token get-symbol))))
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
     (asserts! (is-eq (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name type))) token-symbol) (err ERR-WRONG-TOKEN))
 
     ;; token should be a trait e.g. 'SP3GWX3NE58KXHESRYE4DYQ1S31PQJTCRXB3PE9SB.arkadiko-token
@@ -48,8 +51,11 @@
 )
 
 (define-public (deposit (token <mock-ft-trait>) (additional-ucollateral-amount uint))
-  (begin
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
 
     (match (contract-call? token transfer additional-ucollateral-amount tx-sender (as-contract tx-sender))
       success (ok true)
@@ -59,8 +65,11 @@
 )
 
 (define-public (withdraw (token <mock-ft-trait>) (vault-owner principal) (ucollateral-amount uint))
-  (begin
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
 
     (match (as-contract (contract-call? token transfer ucollateral-amount (as-contract tx-sender) vault-owner))
       success (ok true)
@@ -72,6 +81,7 @@
 (define-public (mint (token (string-ascii 12)) (vault-owner principal) (ucollateral-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (not (is-eq token "STX")) (err ERR-WRONG-TOKEN))
 
     (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token ucollateral-amount collateral-type)) current-debt)))
       (if (>= max-new-debt extra-debt)
@@ -86,8 +96,11 @@
 )
 
 (define-public (burn (token <mock-ft-trait>) (vault-owner principal) (collateral-to-return uint))
-  (begin
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
 
     (match (as-contract (contract-call? token transfer collateral-to-return (as-contract tx-sender) vault-owner))
       transferred (ok true)
@@ -97,8 +110,12 @@
 )
 
 (define-public (redeem-collateral (token <mock-ft-trait>) (ucollateral uint) (owner principal))
-  (begin
+  (let (
+    (token-symbol (unwrap-panic (contract-call? token get-symbol)))
+  )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
+    
     (as-contract (contract-call? token transfer ucollateral (as-contract tx-sender) owner))
   )
 )

--- a/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
@@ -49,12 +49,13 @@
   )
 )
 
-(define-public (deposit (token <mock-ft-trait>) (additional-ucollateral-amount uint))
+(define-public (deposit (token <mock-ft-trait>) (token-string (string-ascii 12)) (additional-ucollateral-amount uint))
   (let (
     (token-symbol (unwrap-panic (contract-call? token get-symbol)))
   )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
-    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
+    (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
 
     (match (contract-call? token transfer additional-ucollateral-amount tx-sender (as-contract tx-sender))
       success (ok true)
@@ -63,11 +64,12 @@
   )
 )
 
-(define-public (withdraw (token <mock-ft-trait>) (vault-owner principal) (ucollateral-amount uint))
+(define-public (withdraw (token <mock-ft-trait>) (token-string (string-ascii 12)) (vault-owner principal) (ucollateral-amount uint))
   (let (
     (token-symbol (unwrap-panic (contract-call? token get-symbol)))
   )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
     (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
 
     (match (as-contract (contract-call? token transfer ucollateral-amount (as-contract tx-sender) vault-owner))
@@ -77,12 +79,12 @@
   )
 )
 
-(define-public (mint (token (string-ascii 12)) (vault-owner principal) (ucollateral-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
+(define-public (mint (token-string (string-ascii 12)) (vault-owner principal) (ucollateral-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
-    (asserts! (not (is-eq token "STX")) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
 
-    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token ucollateral-amount collateral-type)) current-debt)))
+    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token-string ucollateral-amount collateral-type)) current-debt)))
       (if (>= max-new-debt extra-debt)
         (match (as-contract (contract-call? .arkadiko-dao mint-token .xusd-token extra-debt vault-owner))
           success (ok true)

--- a/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
@@ -110,12 +110,13 @@
   )
 )
 
-(define-public (redeem-collateral (token <mock-ft-trait>) (ucollateral uint) (owner principal))
+(define-public (redeem-collateral (token <mock-ft-trait>) (token-string (string-ascii 12)) (ucollateral uint) (owner principal))
   (let (
     (token-symbol (unwrap-panic (contract-call? token get-symbol)))
   )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
-    (asserts! (not (is-eq token-symbol "STX")) (err ERR-WRONG-TOKEN))
+    (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
+    (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
     
     (as-contract (contract-call? token transfer ucollateral (as-contract tx-sender) owner))
   )

--- a/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-sip10-reserve-v1-1.clar
@@ -33,14 +33,13 @@
 )
 
 ;; (match (print (ft-transfer? token ucollateral-amount sender (as-contract tx-sender)))
-(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (type (string-ascii 12)) (ucollateral-amount uint) (debt uint) (sender principal))
+(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (ucollateral-amount uint) (debt uint) (sender principal))
   (let (
     (token-symbol (unwrap-panic (contract-call? token get-symbol)))
   )
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq token-string token-symbol) (err ERR-WRONG-TOKEN))
     (asserts! (not (is-eq token-string "STX")) (err ERR-WRONG-TOKEN))
-    (asserts! (is-eq (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name type))) token-symbol) (err ERR-WRONG-TOKEN))
 
     ;; token should be a trait e.g. 'SP3GWX3NE58KXHESRYE4DYQ1S31PQJTCRXB3PE9SB.arkadiko-token
     (match (contract-call? token transfer ucollateral-amount sender (as-contract tx-sender))

--- a/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
@@ -105,9 +105,10 @@
 )
 
 ;; deposit extra collateral in vault
-(define-public (deposit (token <mock-ft-trait>) (additional-ustx-amount uint))
+(define-public (deposit (token <mock-ft-trait>) (token-string (string-ascii 12)) (additional-ustx-amount uint))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
 
     (match (print (stx-transfer? additional-ustx-amount tx-sender (as-contract tx-sender)))
       success (begin
@@ -120,9 +121,10 @@
 )
 
 ;; withdraw collateral (e.g. if collateral goes up in value)
-(define-public (withdraw (token <mock-ft-trait>) (vault-owner principal) (ustx-amount uint))
+(define-public (withdraw (token <mock-ft-trait>) (token-string (string-ascii 12)) (vault-owner principal) (ustx-amount uint))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
 
     (match (print (as-contract (stx-transfer? ustx-amount (as-contract tx-sender) vault-owner)))
       success (ok true)
@@ -132,11 +134,12 @@
 )
 
 ;; mint new tokens when collateral to debt allows it (i.e. > collateral-to-debt-ratio)
-(define-public (mint (token (string-ascii 12)) (vault-owner principal) (ustx-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
+(define-public (mint (token-string (string-ascii 12)) (vault-owner principal) (ustx-amount uint) (current-debt uint) (extra-debt uint) (collateral-type (string-ascii 12)))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
 
-    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token ustx-amount collateral-type)) current-debt)))
+    (let ((max-new-debt (- (unwrap-panic (calculate-xusd-count token-string ustx-amount collateral-type)) current-debt)))
       (if (>= max-new-debt extra-debt)
         (match (print (as-contract (contract-call? .arkadiko-dao mint-token .xusd-token extra-debt vault-owner)))
           success (ok true)

--- a/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
@@ -181,9 +181,11 @@
   )
 )
 
-(define-public (redeem-collateral (token <mock-ft-trait>) (stx-collateral uint) (owner principal))
+(define-public (redeem-collateral (token <mock-ft-trait>) (token-string (string-ascii 12)) (stx-collateral uint) (owner principal))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
+
     (as-contract (stx-transfer? stx-collateral (as-contract tx-sender) owner))
   )
 )

--- a/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
+++ b/clarity/contracts/arkadiko-stx-reserve-v1-1.clar
@@ -89,11 +89,10 @@
 ;; accept collateral in STX tokens
 ;; save STX in stx-reserve-address
 ;; calculate price and collateralisation ratio
-(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (type (string-ascii 12)) (ustx-amount uint) (debt uint) (sender principal))
+(define-public (collateralize-and-mint (token <mock-ft-trait>) (token-string (string-ascii 12)) (ustx-amount uint) (debt uint) (sender principal))
   (begin
     (asserts! (is-eq contract-caller .arkadiko-freddie-v1-1) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq token-string "STX") (err ERR-WRONG-TOKEN))
-    (asserts! (is-eq (get token (unwrap-panic (contract-call? .arkadiko-collateral-types-v1-1 get-collateral-type-by-name type))) "STX") (err ERR-WRONG-TOKEN))
 
     (match (print (stx-transfer? ustx-amount sender (as-contract tx-sender)))
       success (begin

--- a/clarity/contracts/arkadiko-vault-manager-trait-v1.clar
+++ b/clarity/contracts/arkadiko-vault-manager-trait-v1.clar
@@ -14,7 +14,7 @@
     (liquidate (uint) (response (tuple (ustx-amount uint) (extra-debt uint) (vault-debt uint) (discount uint)) uint))
     (finalize-liquidation (uint uint) (response bool uint))
 
-    (redeem-auction-collateral (<mock-ft-trait> <vault-trait> uint principal) (response bool uint))
+    (redeem-auction-collateral (<mock-ft-trait> (string-ascii 12) <vault-trait> uint principal) (response bool uint))
 
     (get-xusd-balance () (response uint bool))
     (set-stx-redeemable (uint) (response bool uint))

--- a/clarity/contracts/arkadiko-vault-trait-v1.clar
+++ b/clarity/contracts/arkadiko-vault-trait-v1.clar
@@ -13,10 +13,10 @@
     (collateralize-and-mint (<mock-ft-trait> (string-ascii 12) uint uint principal) (response uint uint))
 
     ;; deposit extra collateral
-    (deposit (<mock-ft-trait> uint) (response bool uint))
+    (deposit (<mock-ft-trait> (string-ascii 12) uint) (response bool uint))
 
     ;; withdraw excess collateral
-    (withdraw (<mock-ft-trait> principal uint) (response bool uint))
+    (withdraw (<mock-ft-trait> (string-ascii 12) principal uint) (response bool uint))
 
     ;; mint additional stablecoin
     (mint ((string-ascii 12) principal uint uint uint (string-ascii 12)) (response bool uint))

--- a/clarity/contracts/arkadiko-vault-trait-v1.clar
+++ b/clarity/contracts/arkadiko-vault-trait-v1.clar
@@ -10,7 +10,7 @@
     (calculate-current-collateral-to-debt-ratio ((string-ascii 12) uint uint) (response uint uint))
 
     ;; collateralize tokens and mint stablecoin according to collateral-to-debt ratio
-    (collateralize-and-mint (<mock-ft-trait> (string-ascii 12) (string-ascii 12) uint uint principal) (response uint uint))
+    (collateralize-and-mint (<mock-ft-trait> (string-ascii 12) uint uint principal) (response uint uint))
 
     ;; deposit extra collateral
     (deposit (<mock-ft-trait> uint) (response bool uint))

--- a/clarity/contracts/arkadiko-vault-trait-v1.clar
+++ b/clarity/contracts/arkadiko-vault-trait-v1.clar
@@ -28,7 +28,7 @@
     ;; (liquidate (uint uint) (response (tuple (ustx-amount uint) (debt uint)) uint))
 
     ;; redeem collateral after an auction ran
-    (redeem-collateral (<mock-ft-trait> uint principal) (response bool uint))
+    (redeem-collateral (<mock-ft-trait> (string-ascii 12) uint principal) (response bool uint))
 
     (set-tokens-to-stack (uint) (response bool uint))
   )

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -557,68 +557,6 @@ Clarinet.test({
 
 Clarinet.test({
   name:
-    "auction engine: redeem collateral using wrong contracts",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
-    let deployer = accounts.get("deployer")!;
-    let wallet_1 = accounts.get("wallet_1")!;
-
-    // Initialize price of STX to $2 in the oracle
-    let result = updatePrice(chain, deployer, 200);
-
-    // Create vault - 1000 STX, 1300 xUSD
-    result = createVault(chain, deployer, 1000, 1300);
-    result.expectOk().expectUint(1300000000);
-
-    // Upate price to $1.5 and notify risky vault
-    result = updatePrice(chain, deployer, 150);
-    result = notifyRiskyVault(chain, deployer);
-    result.expectOk().expectUint(5200);
-
-    // Bid on first 1000 xUSD
-    result = bid(chain, deployer, bidSize);
-    result.expectOk().expectBool(true);
-
-    // Bid on rest
-    result = bid(chain, deployer, 379, 1, 1) // 1.44 (discounted price of STX) * minimum collateral
-    result.expectOk().expectBool(true);
-
-    // Wrong token
-    let block = chain.mineBlock([
-      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
-        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
-        ),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
-        ),
-        types.uint(1),
-        types.uint(0)
-      ], deployer.address)
-    ]);
-    block.receipts[0].result.expectErr().expectUint(212);
-
-    // Wrong reserve 
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
-        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
-        ),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1",
-        ),
-        types.uint(1),
-        types.uint(0)
-      ], deployer.address)
-    ]);
-    // TODO: would expect an error as the reserve is wrong
-    // block.receipts[0].result.expectErr().expectUint(123);
-  }
-});
-
-Clarinet.test({
-  name:
     "auction engine: test closing of auction once dept covered",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     let deployer = accounts.get("deployer")!;
@@ -729,6 +667,264 @@ Clarinet.test({
   }
 });
 
+Clarinet.test({
+  name:
+    "auction engine: redeem collateral using wrong token contract",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault - 1000 STX, 1300 xUSD
+    result = createVault(chain, deployer, 1000, 1300);
+    result.expectOk().expectUint(1300000000);
+
+    // Upate price to $1.5 and notify risky vault
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer);
+    result.expectOk().expectUint(5200);
+
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, bidSize);
+    result.expectOk().expectBool(true);
+
+    // Bid on rest
+    result = bid(chain, deployer, 379, 1, 1) // 1.44 (discounted price of STX) * minimum collateral
+    result.expectOk().expectBool(true);
+
+    // Wrong token
+    let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(212);
+
+  }
+});
+
+Clarinet.test({
+  name:
+    "auction engine: can not redeem xSTX from STX reserve",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+    let wallet_2 = accounts.get("wallet_2")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault for wallet_1 - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Upate price to $1.5 and notify risky vault 1
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer, 1);
+    result.expectOk().expectUint(5200);
+    
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, 1000);
+    result.expectOk().expectBool(true);
+
+    // Bid on second lot 
+    result = bid(chain, deployer, 1000, 1, 1);
+    result.expectOk().expectBool(true);
+
+    // Vault is stacking, so we get xSTXN
+    let call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-freddie-v1-1",
+      "get-vault-by-id",
+      [types.uint(1)],
+      deployer.address
+    );
+    let vault = call.result.expectTuple();
+    vault['revoked-stacking'].expectBool(false);
+    vault['stacked-tokens'].expectUint(1000000000);
+
+    // Withdrawing the xSTX tokens
+    let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(118);
+  }
+});
+
+Clarinet.test({
+  name:
+    "auction engine: can not exchange xSTX for STX while vault is stacking",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+    let wallet_2 = accounts.get("wallet_2")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault for wallet_1 - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Upate price to $1.5 and notify risky vault 1
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer, 1);
+    result.expectOk().expectUint(5200);
+    
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, 1000);
+    result.expectOk().expectBool(true);
+
+    // Bid on second lot 
+    result = bid(chain, deployer, 1000, 1, 1);
+    result.expectOk().expectBool(true);
+
+    let call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-freddie-v1-1",
+      "get-vault-by-id",
+      [types.uint(1)],
+      deployer.address
+    );
+    let vault = call.result.expectTuple();
+    vault['revoked-stacking'].expectBool(false);
+    vault['stacked-tokens'].expectUint(1000000000);
+
+    // TODO: redeem xSTX
+
+    // TODO: try to exchange xSTX for STX while vault still stacking
+
+    // TODO: exchange xSTX for STX
+
+  }
+});
+
+Clarinet.test({
+  name:
+    "auction engine: should be able to redeem STX when vault not stacking",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+    let wallet_2 = accounts.get("wallet_2")!;
+
+    // Initialize price of STX to $2 in the oracle
+    let result = updatePrice(chain, deployer, 200);
+
+    // Create vault - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Create vault - 1000 STX, 1100 xUSD
+    result = createVault(chain, deployer, 1000, 1100);
+    result.expectOk().expectUint(1100000000);
+
+    // Turn off stacking
+    let block = chain.mineBlock([
+      // revoke stacking for vault 1
+      Tx.contractCall("arkadiko-freddie-v1-1", "toggle-stacking", [
+        types.uint(1)
+      ], deployer.address),
+      // now vault 1 has revoked stacking, enable vault withdrawals
+      Tx.contractCall("arkadiko-freddie-v1-1", "enable-vault-withdrawals", [
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stacker-v1-1"),
+        types.uint(1)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true);
+
+    // Upate price to $1.5 and notify risky vault 1
+    result = updatePrice(chain, deployer, 150);
+    result = notifyRiskyVault(chain, deployer, 1);
+    result.expectOk().expectUint(5200);
+    result = notifyRiskyVault(chain, deployer, 2);
+    result.expectOk().expectUint(5200);
+
+    // Bid on first 1000 xUSD
+    result = bid(chain, deployer, 1000);
+    result.expectOk().expectBool(true);
+
+    // Bid on second lot 
+    result = bid(chain, deployer, 1000, 1, 1);
+    result.expectOk().expectBool(true);
+
+    // Vault is not stacking, so we got STX
+    let call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
+    call = await chain.callReadOnlyFn(
+      "arkadiko-freddie-v1-1",
+      "get-vault-by-id",
+      [types.uint(1)],
+      deployer.address
+    );
+    let vault = call.result.expectTuple();
+    vault['revoked-stacking'].expectBool(true);
+    vault['stacked-tokens'].expectUint(0);
+
+    // Can not redeem xSTX tokens
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectErr().expectUint(98);
+
+    // Redeem the STX tokens
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "redeem-lot-collateral", [
+        types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-freddie-v1-1'),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token", // not used for stx reserve
+        ),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1",
+        ),
+        types.uint(1),
+        types.uint(0)
+      ], deployer.address)
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true);
+  }
+});
+
 // ---------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------
@@ -788,7 +984,7 @@ function redeemLotCollateral(chain: Chain, user: Account) {
         "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
       ),
       types.principal(
-        "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1", // TODO: test if stx reserve
+        "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1", 
       ),
       types.uint(1),
       types.uint(0)

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -744,7 +744,6 @@ function createVault(chain: Chain, user: Account, collateral: number, xusd: numb
       types.uint(collateral * 1000000), 
       types.uint(xusd * 1000000), 
       types.ascii("STX-A"),
-      types.ascii("STX"),
       types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
       types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
     ], user.address)

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -743,7 +743,6 @@ function createVault(chain: Chain, user: Account, collateral: number, xusd: numb
     Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
       types.uint(collateral * 1000000), 
       types.uint(xusd * 1000000), 
-      types.principal(user.address),
       types.ascii("STX-A"),
       types.ascii("STX"),
       types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),

--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -117,6 +117,11 @@ Clarinet.test({
     ], deployer.address);
     call.result.expectOk().expectUint(79000000); // 79 dollars left
 
+    call = await chain.callReadOnlyFn("xstx-token", "get-balance-of", [
+      types.principal(deployer.address),
+    ], deployer.address);
+    call.result.expectOk().expectUint(0);
+
     // now try withdrawing the xSTX tokens that are not mine
     result = redeemLotCollateral(chain, wallet_1);
     result.expectErr().expectUint(2403);
@@ -185,8 +190,8 @@ Clarinet.test({
     block = chain.mineBlock([
       Tx.contractCall("arkadiko-freddie-v1-1", "withdraw-leftover-collateral", [
         types.uint(1),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token"),
       ], deployer.address)
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
@@ -601,7 +606,7 @@ Clarinet.test({
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
         ),
         types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1",
         ),
         types.uint(1),
         types.uint(0)
@@ -783,7 +788,7 @@ function redeemLotCollateral(chain: Chain, user: Account) {
         "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xstx-token",
       ),
       types.principal(
-        "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
+        "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1", // TODO: test if stx reserve
       ),
       types.uint(1),
       types.uint(0)

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -393,6 +393,41 @@ Clarinet.test({
       ], deployer.address),
     ]);
     block.receipts[0].result.expectErr().expectUint(98); // wrong token error
+
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
+        types.ascii("DIKO"),
+        types.uint(200),
+      ], deployer.address),
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(500000000),
+        types.uint(925000),
+        types.principal(deployer.address),
+        types.ascii("DIKO-A"),
+        types.ascii("DIKO"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xusd-token",
+        ),
+      ], deployer.address),
+    ]);
+    block.receipts[1].result.expectErr().expectUint(98); // wrong token error
+
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(500000000),
+        types.uint(925000),
+        types.principal(deployer.address),
+        types.ascii("DIKO-A"),
+        types.ascii("STX"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+      ], deployer.address),
+    ]);
+    block.receipts[0].result.expectErr().expectUint(118); // wrong token error
+
   }
 });
 

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -432,7 +432,6 @@ Clarinet.test({
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
-    // TODO
     block.receipts[0].result
       .expectErr()
       .expectUint(45);
@@ -445,7 +444,6 @@ Clarinet.test({
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1")
       ], deployer.address),
     ]);
-    // TODO
     block.receipts[0].result
       .expectErr()
       .expectUint(118);
@@ -459,7 +457,6 @@ Clarinet.test({
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
     ]);
-    // TODO
     block.receipts[0].result
       .expectErr()
       .expectUint(46);
@@ -473,7 +470,6 @@ Clarinet.test({
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
       ], deployer.address),
     ]);
-    // TODO
     block.receipts[0].result
       .expectErr()
       .expectUint(112);

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -26,7 +26,6 @@ Clarinet.test({
         types.uint(5000000),
         types.uint(1925000),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -108,7 +107,6 @@ Clarinet.test({
         types.uint(5000000),
         types.uint(1925000),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -134,7 +132,6 @@ Clarinet.test({
         types.uint(900000000), // 900 STX (1800 USD worth of collateral)
         types.uint(1000000000), // 1000 xUSD
         types.ascii("STX-B"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -166,7 +163,6 @@ Clarinet.test({
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -194,7 +190,6 @@ Clarinet.test({
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -262,7 +257,6 @@ Clarinet.test({
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -317,7 +311,7 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "freddie: minting xUSD with conflicting FT <> collateral type is illegal",
+  name: "freddie: collateralize-and-mint with wrong parameters",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     let deployer = accounts.get("deployer")!;
     let block = chain.mineBlock([
@@ -329,7 +323,6 @@ Clarinet.test({
         types.uint(5000000),
         types.uint(1925000),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -347,7 +340,6 @@ Clarinet.test({
         types.uint(500000000),
         types.uint(925000),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -361,21 +353,6 @@ Clarinet.test({
         types.uint(500000000),
         types.uint(925000),
         types.ascii("STX-A"),
-        types.ascii("DIKO"),
-        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
-        types.principal(
-          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
-        ),
-      ], deployer.address),
-    ]);
-    block.receipts[0].result.expectErr().expectUint(118); // wrong token error
-
-    block = chain.mineBlock([
-      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
-        types.uint(500000000),
-        types.uint(925000),
-        types.ascii("STX-A"),
-        types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -393,7 +370,6 @@ Clarinet.test({
         types.uint(500000000),
         types.uint(925000),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.xusd-token",
@@ -407,7 +383,6 @@ Clarinet.test({
         types.uint(500000000),
         types.uint(925000),
         types.ascii("DIKO-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -418,6 +393,94 @@ Clarinet.test({
 
   }
 });
+
+Clarinet.test({
+  name: "freddie: wrong parameters for deposit, withdraw, mint, burn",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+    let block = chain.mineBlock([
+      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
+        types.ascii("STX"),
+        types.uint(77),
+      ], deployer.address),
+      Tx.contractCall("arkadiko-oracle-v1-1", "update-price", [
+        types.ascii("DIKO"),
+        types.uint(50),
+      ], deployer.address),
+      Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
+        types.uint(5000000),
+        types.uint(1),
+        types.ascii("DIKO-A"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
+        types.principal(
+          "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
+        ),
+      ], deployer.address),
+    ]);
+
+    block.receipts[2].result
+      .expectOk()
+      .expectUint(1);
+
+      // Should not be able to deposit in STX reserve
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "deposit", [
+        types.uint(1),
+        types.uint(500000000), // 500 STX
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
+      ], deployer.address)
+    ]);
+    // TODO
+    // block.receipts[0].result
+    //   .expectErr()
+    //   .expectUint(45);
+    
+    // Mint extra
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "mint", [
+        types.uint(1),
+        types.uint(1), // mint 1 xUSD
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1")
+      ], deployer.address),
+    ]);
+    // TODO
+    // block.receipts[0].result
+    //   .expectErr()
+    //   .expectUint(118);
+
+    // Withdraw
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "withdraw", [
+        types.uint(1),
+        types.uint(1), // 1 STX
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
+      ], deployer.address)
+    ]);
+    // TODO
+    // block.receipts[0].result
+    //   .expectErr()
+    //   .expectUint(46);
+
+    //  Burn
+    block = chain.mineBlock([
+      Tx.contractCall("arkadiko-freddie-v1-1", "burn", [
+        types.uint(1),
+        types.uint(1), // burn 1 xUSD
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
+        types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token")
+      ], deployer.address),
+    ]);
+    // TODO
+    // block.receipts[0].result
+    //   .expectErr()
+    //   .expectUint(112);
+
+  },
+});
+
 
 Clarinet.test({
   name: "freddie: mint and burn",
@@ -434,7 +497,6 @@ Clarinet.test({
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -537,7 +599,6 @@ Clarinet.test({
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -621,7 +682,6 @@ Clarinet.test({
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -687,7 +747,6 @@ Clarinet.test({
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -719,7 +778,6 @@ Clarinet.test({
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)
@@ -727,3 +785,4 @@ Clarinet.test({
     block.receipts[2].result.expectErr().expectUint(411);
   }
 });
+

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -25,7 +25,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -108,7 +107,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -135,7 +133,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(900000000), // 900 STX (1800 USD worth of collateral)
         types.uint(1000000000), // 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-B"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -168,7 +165,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -197,7 +193,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -266,7 +261,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -334,7 +328,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
@@ -353,7 +346,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(925000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -368,7 +360,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -383,7 +374,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
@@ -402,7 +392,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(925000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
@@ -417,7 +406,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(925000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -445,7 +433,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -549,7 +536,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -634,7 +620,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -701,7 +686,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1"),
@@ -734,7 +718,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(300000000), // mint 300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -433,9 +433,9 @@ Clarinet.test({
       ], deployer.address)
     ]);
     // TODO
-    // block.receipts[0].result
-    //   .expectErr()
-    //   .expectUint(45);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(45);
     
     // Mint extra
     block = chain.mineBlock([
@@ -446,9 +446,9 @@ Clarinet.test({
       ], deployer.address),
     ]);
     // TODO
-    // block.receipts[0].result
-    //   .expectErr()
-    //   .expectUint(118);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(118);
 
     // Withdraw
     block = chain.mineBlock([
@@ -460,9 +460,9 @@ Clarinet.test({
       ], deployer.address)
     ]);
     // TODO
-    // block.receipts[0].result
-    //   .expectErr()
-    //   .expectUint(46);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(46);
 
     //  Burn
     block = chain.mineBlock([
@@ -474,9 +474,9 @@ Clarinet.test({
       ], deployer.address),
     ]);
     // TODO
-    // block.receipts[0].result
-    //   .expectErr()
-    //   .expectUint(112);
+    block.receipts[0].result
+      .expectErr()
+      .expectUint(112);
 
   },
 });

--- a/clarity/tests/arkadiko-liquidator-v1-1_test.ts
+++ b/clarity/tests/arkadiko-liquidator-v1-1_test.ts
@@ -21,7 +21,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(100000000), // 100 STX
         types.uint(130000000), // mint 130 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),

--- a/clarity/tests/arkadiko-liquidator-v1-1_test.ts
+++ b/clarity/tests/arkadiko-liquidator-v1-1_test.ts
@@ -22,7 +22,6 @@ Clarinet.test({
         types.uint(100000000), // 100 STX
         types.uint(130000000), // mint 130 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address)

--- a/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
+++ b/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
@@ -35,7 +35,6 @@ Clarinet.test({
         types.uint(20000000),
         types.uint(5000000),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -118,7 +117,6 @@ Clarinet.test({
         types.uint(20000000),
         types.uint(5000000),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -196,7 +194,6 @@ Clarinet.test({
         types.uint(20000000),
         types.uint(5000000),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -285,7 +282,6 @@ Clarinet.test({
         types.uint(20000000),
         types.uint(5000000),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),
@@ -360,7 +356,6 @@ Clarinet.test({
         types.uint(20000000),
         types.uint(5000000),
         types.ascii("DIKO-A"),
-        types.ascii("DIKO"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-sip10-reserve-v1-1",
         ),

--- a/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
+++ b/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
@@ -34,7 +34,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal(
@@ -118,7 +117,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal(
@@ -197,7 +195,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal(
@@ -287,7 +284,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal(
@@ -363,7 +359,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(20000000),
         types.uint(5000000),
-        types.principal(deployer.address),
         types.ascii("DIKO-A"),
         types.ascii("DIKO"),
         types.principal(

--- a/clarity/tests/arkadiko-stacker-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stacker-v1-1_test.ts
@@ -19,7 +19,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -30,7 +29,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(400000000), // mint 400 xUSD
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -98,7 +96,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -155,7 +152,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -166,7 +162,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000000),
         types.uint(400000000), // mint 400 xUSD
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -244,7 +239,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(1300000000), // mint 1300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -350,7 +344,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(1000000000), // 1000 STX
         types.uint(1300000000), // mint 1300 xUSD
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),

--- a/clarity/tests/arkadiko-stacker-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stacker-v1-1_test.ts
@@ -20,7 +20,6 @@ Clarinet.test({
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -30,7 +29,6 @@ Clarinet.test({
         types.uint(500000000),
         types.uint(400000000), // mint 400 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -97,7 +95,6 @@ Clarinet.test({
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -153,7 +150,6 @@ Clarinet.test({
         types.uint(1000000000),
         types.uint(1000000000), // mint 1000 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -163,7 +159,6 @@ Clarinet.test({
         types.uint(500000000),
         types.uint(400000000), // mint 400 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -240,7 +235,6 @@ Clarinet.test({
         types.uint(1000000000), // 1000 STX
         types.uint(1300000000), // mint 1300 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address),
@@ -345,7 +339,6 @@ Clarinet.test({
         types.uint(1000000000), // 1000 STX
         types.uint(1300000000), // mint 1300 xUSD
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
       ], deployer.address),

--- a/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
+++ b/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
@@ -20,7 +20,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -49,7 +48,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(500000),
         types.uint(192500),
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -83,7 +81,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -124,7 +121,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(deployer.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
@@ -148,7 +144,6 @@ Clarinet.test({
       Tx.contractCall("arkadiko-freddie-v1-1", "collateralize-and-mint", [
         types.uint(5000000),
         types.uint(1925000),
-        types.principal(wallet_1.address),
         types.ascii("STX-A"),
         types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),

--- a/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
+++ b/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
@@ -21,7 +21,6 @@ Clarinet.test({
         types.uint(5000000),
         types.uint(1925000),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -49,7 +48,6 @@ Clarinet.test({
         types.uint(500000),
         types.uint(192500),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -82,7 +80,6 @@ Clarinet.test({
         types.uint(5000000),
         types.uint(1925000),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -122,7 +119,6 @@ Clarinet.test({
         types.uint(5000000),
         types.uint(1925000),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",
@@ -145,7 +141,6 @@ Clarinet.test({
         types.uint(5000000),
         types.uint(1925000),
         types.ascii("STX-A"),
-        types.ascii("STX"),
         types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stx-reserve-v1-1"),
         types.principal(
           "STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token",


### PR DESCRIPTION
Refactored 'collateralize-and-mint' and removed arguments: sender, collateral-token and collateral-type. By having less arguments we simplify the code and reduce the amount of asserts.

Updated the reserve trait for withdraw, deposit and redeem-lot-collateral to accept a token-string. This is provided by freddie, based on the vault collateral. This way we can check if the reserve matches the vault collateral. Added tests.
